### PR TITLE
현재 구현된 피드백 관련 뷰에서 실제 유저id 설정 (#64)

### DIFF
--- a/GimiFeedback/GimiFeedback/Model/FeedbackChannel.swift
+++ b/GimiFeedback/GimiFeedback/Model/FeedbackChannel.swift
@@ -9,13 +9,13 @@ import Foundation
 
 struct FeedbackChannel: Codable, Identifiable {
     let id: UUID
-    let userID: UUID
+    let userID: String
     let channelTitle: String
     var content: String
     
     init(
         id: UUID = UUID(),
-        userID: UUID,
+        userID: String,
         channelTitle: String,
         content: String
     ) {

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelCreate/ChannelCreateViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelCreate/ChannelCreateViewModel.swift
@@ -35,7 +35,7 @@ extension ChannelCreateViewModel {
             isLoading = true
             
             let newChannel = FeedbackChannel(
-                userID: UUID(),
+                userID: FirebaseAuthManager.currentUserID ?? "",
                 channelTitle: title,
                 content: description
             )

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListView.swift
@@ -9,37 +9,43 @@ struct ChannelListView: View {
     
     let columns: [GridItem] = Array(repeating: .init(.flexible()), count: 3)
     
-    private var isLoading: Bool {
-        !viewModel.isChannelListLoading
-    }
-    
     var body: some View {
         NavigationStack {
             ScrollView {
-                LazyVGrid(columns: columns, alignment: .center, spacing: 32) {
-                    ForEach(viewModel.channelList) { item in
-                        NavigationLink(destination: {
-                            ChannelDetailView(channelItem: item.channel)
-                        }) {
-                            VStack(alignment: .center) {
-                                Image(systemName: "folder.fill")
-                                    .resizable()
-                                    .frame(width: 85, height: 67)
-                                    .overlay(alignment: .topTrailing) {
-                                        Circle()
-                                            .fill(.red)
-                                            .frame(width: 28, height: 28)
-                                            .overlay {
-                                                
-                                                Text("\(item.visibleFeedbackCount)")
-                                                    .foregroundStyle(Color.white)
-                                            }
-                                    }
-                                
-                                Text("title: \(item.channel.channelTitle)")
-                                
-                                Text("총 피드백 \(item.feedbackCount)개")
-                                    .foregroundStyle(Color.white)
+                if viewModel.channelList.isEmpty {
+                    VStack(alignment: .center, spacing: 8) {
+                        Text("피드백을 받기 위해\n채널을 생성해보세요.")
+                        
+                        Button(action: { }) {
+                            Text("채널 생성하기")
+                        }
+                    }
+                } else {
+                    LazyVGrid(columns: columns, alignment: .center, spacing: 32) {
+                        ForEach(viewModel.channelList) { item in
+                            NavigationLink(destination: {
+                                ChannelDetailView(channelItem: item.channel)
+                            }) {
+                                VStack(alignment: .center) {
+                                    Image(systemName: "folder.fill")
+                                        .resizable()
+                                        .frame(width: 85, height: 67)
+                                        .overlay(alignment: .topTrailing) {
+                                            Circle()
+                                                .fill(.red)
+                                                .frame(width: 28, height: 28)
+                                                .overlay {
+                                                    
+                                                    Text("\(item.visibleFeedbackCount)")
+                                                        .foregroundStyle(Color.white)
+                                                }
+                                        }
+                                    
+                                    Text("title: \(item.channel.channelTitle)")
+                                    
+                                    Text("총 피드백 \(item.feedbackCount)개")
+                                        .foregroundStyle(Color.white)
+                                }
                             }
                         }
                     }
@@ -48,6 +54,16 @@ struct ChannelListView: View {
             .padding(.top, 32)
             .navigationTitle("기미 피드백")
             .toolbar {
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    Button(action: { }) {
+                        Text("코드 입력")
+                    }
+                    
+                    Button(action: { }) {
+                        Image(systemName: "person.crop.circle")
+                    }
+                }
+                
                 ToolbarItemGroup(placement: .bottomBar) {
                     HStack {
                         Spacer()

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListViewModel.swift
@@ -28,39 +28,44 @@ extension ChannelListViewModel {
     private func fetchChannelList() {
         Task {
             isChannelListLoading = true
-            totalFeedbackCount = .zero
-            
             do {
                 let filteredChannels = try await FirestoreManager.shared.fetch(
                     as: FeedbackChannel.self, .feedbackChannel,
                     whereFeild: "userID",
                     equalData: FirebaseAuthManager.currentUserID)
                 
-                var result: [FeedbackChannelInfo] = []
+                let filteredItemList = try await fetchFilteredChannelList(itemList: filteredChannels)
                 
-                for channel in filteredChannels {
-                    let feedbackList = try await FirestoreManager.shared.fetch(
-                        as: Feedback.self,
-                        .feedback,
-                        whereFeild: "feedbackChannelID",
-                        equalData: channel.id.uuidString)
-                    
-                    result.append(
-                        FeedbackChannelInfo(
-                            channel: channel,
-                            feedbackCount: feedbackList.count,
-                            visibleFeedbackCount: feedbackList.filter({ !$0.visiable }).count))
-                    
-                    totalFeedbackCount += feedbackList.count
-                }
-                
-                channelList = result
+                channelList = filteredItemList
                 
             } catch {
                 errorMessage = error.localizedDescription
             }
             isChannelListLoading = false
         }
+    }
+    
+    private func fetchFilteredChannelList(itemList: [FeedbackChannel]) async throws -> [FeedbackChannelInfo] {
+        var result: [FeedbackChannelInfo] = []
+        totalFeedbackCount = .zero
+        
+        for channel in itemList {
+            let feedbackList = try await FirestoreManager.shared.fetch(
+                as: Feedback.self,
+                .feedback,
+                whereFeild: "feedbackChannelID",
+                equalData: channel.id.uuidString)
+            
+            result.append(
+                FeedbackChannelInfo(
+                    channel: channel,
+                    feedbackCount: feedbackList.count,
+                    visibleFeedbackCount: feedbackList.filter({ !$0.visiable }).count))
+            
+            totalFeedbackCount += feedbackList.count
+        }
+        
+        return result
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListViewModel.swift
@@ -28,31 +28,28 @@ extension ChannelListViewModel {
     private func fetchChannelList() {
         Task {
             isChannelListLoading = true
-            
             totalFeedbackCount = .zero
             
             do {
-                let channels = try await FirestoreManager.shared.fetch(
-                    as: FeedbackChannel.self,
-                    .feedbackChannel
-                )
+                let filteredChannels = try await FirestoreManager.shared.fetch(
+                    as: FeedbackChannel.self, .feedbackChannel,
+                    whereFeild: "userID",
+                    equalData: FirebaseAuthManager.currentUserID)
                 
                 var result: [FeedbackChannelInfo] = []
                 
-                for channel in channels {
+                for channel in filteredChannels {
                     let feedbackList = try await FirestoreManager.shared.fetch(
                         as: Feedback.self,
                         .feedback,
                         whereFeild: "feedbackChannelID",
-                        equalData: channel.id.uuidString
-                    )
+                        equalData: channel.id.uuidString)
                     
                     result.append(
                         FeedbackChannelInfo(
                             channel: channel,
                             feedbackCount: feedbackList.count,
-                            visibleFeedbackCount: feedbackList.filter({ !$0.visiable }).count)
-                    )
+                            visibleFeedbackCount: feedbackList.filter({ !$0.visiable }).count))
                     
                     totalFeedbackCount += feedbackList.count
                 }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
로그인 로직이 완료되어 피드백 채널 생성시 실제 유저 Id를 추가하고
리스트 가져오기에 대해서 현재 로그인된 유저의 채널 리스트만 가져옵니다.



## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

| 모든 피드백 채널 (전) | 현재 로그인된 유저의 피드백 채널 (후) |
|----------|----------|
|<img width="300" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-15 at 23 47 15" src="https://github.com/user-attachments/assets/f190873e-19b5-4e3b-a7d5-1c9927e1d6d1" /> | <img width="300" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-07-15 at 23 47 41" src="https://github.com/user-attachments/assets/69de800d-12f8-45f9-9844-ef5dbcd06ed2" />|


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
