### PR TITLE
피드백 코드 입력 화면 구현(#27)

### DIFF
--- a/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
+++ b/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		EE465EF82E2632B20096109A /* ChannelCraeteCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE465EF72E2632B20096109A /* ChannelCraeteCompleteView.swift */; };
 		EE465EFC2E2650970096109A /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE465EFB2E2650970096109A /* HomeView.swift */; };
 		EE465F022E26510A0096109A /* ChannelListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE465F012E2651070096109A /* ChannelListItemView.swift */; };
+		EE465F062E27B2420096109A /* InputCodeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE465F052E27B23D0096109A /* InputCodeViewModel.swift */; };
 		EE82DF9B2E24D5CD00EC1AFF /* ChannelCreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE82DF9A2E24D5C900EC1AFF /* ChannelCreateView.swift */; };
 		EE82DF9D2E24D5DA00EC1AFF /* ChannelCreateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE82DF9C2E24D5D400EC1AFF /* ChannelCreateViewModel.swift */; };
 		EE82DFA22E24D63A00EC1AFF /* ChannelCreateCompleteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE82DF9F2E24D63A00EC1AFF /* ChannelCreateCompleteViewModel.swift */; };
@@ -87,6 +88,7 @@
 		EE465EF72E2632B20096109A /* ChannelCraeteCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelCraeteCompleteView.swift; sourceTree = "<group>"; };
 		EE465EFB2E2650970096109A /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		EE465F012E2651070096109A /* ChannelListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListItemView.swift; sourceTree = "<group>"; };
+		EE465F052E27B23D0096109A /* InputCodeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputCodeViewModel.swift; sourceTree = "<group>"; };
 		EE82DF9A2E24D5C900EC1AFF /* ChannelCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelCreateView.swift; sourceTree = "<group>"; };
 		EE82DF9C2E24D5D400EC1AFF /* ChannelCreateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelCreateViewModel.swift; sourceTree = "<group>"; };
 		EE82DF9F2E24D63A00EC1AFF /* ChannelCreateCompleteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelCreateCompleteViewModel.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 		EE41FD7E2E223D180002E595 /* InputCode */ = {
 			isa = PBXGroup;
 			children = (
+				EE465F052E27B23D0096109A /* InputCodeViewModel.swift */,
 				EE41FD812E223D720002E595 /* InputCodeView.swift */,
 			);
 			path = InputCode;
@@ -511,6 +514,7 @@
 				EE856A492E1CD2D7006820B9 /* Feedback.swift in Sources */,
 				EE856A512E1CD418006820B9 /* ChannelListView.swift in Sources */,
 				EE856A442E1CD244006820B9 /* Color+Extension.swift in Sources */,
+				EE465F062E27B2420096109A /* InputCodeViewModel.swift in Sources */,
 				EE41FEED2E225A250002E595 /* FirebaseAuthManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
+++ b/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		EE465EFC2E2650970096109A /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE465EFB2E2650970096109A /* HomeView.swift */; };
 		EE465F022E26510A0096109A /* ChannelListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE465F012E2651070096109A /* ChannelListItemView.swift */; };
 		EE465F062E27B2420096109A /* InputCodeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE465F052E27B23D0096109A /* InputCodeViewModel.swift */; };
+		EE465F6D2E27E8CD0096109A /* FeedbackWriteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE465F6C2E27E8CC0096109A /* FeedbackWriteViewModel.swift */; };
 		EE82DF9B2E24D5CD00EC1AFF /* ChannelCreateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE82DF9A2E24D5C900EC1AFF /* ChannelCreateView.swift */; };
 		EE82DF9D2E24D5DA00EC1AFF /* ChannelCreateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE82DF9C2E24D5D400EC1AFF /* ChannelCreateViewModel.swift */; };
 		EE82DFA22E24D63A00EC1AFF /* ChannelCreateCompleteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE82DF9F2E24D63A00EC1AFF /* ChannelCreateCompleteViewModel.swift */; };
@@ -89,6 +90,7 @@
 		EE465EFB2E2650970096109A /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		EE465F012E2651070096109A /* ChannelListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelListItemView.swift; sourceTree = "<group>"; };
 		EE465F052E27B23D0096109A /* InputCodeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputCodeViewModel.swift; sourceTree = "<group>"; };
+		EE465F6C2E27E8CC0096109A /* FeedbackWriteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackWriteViewModel.swift; sourceTree = "<group>"; };
 		EE82DF9A2E24D5C900EC1AFF /* ChannelCreateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelCreateView.swift; sourceTree = "<group>"; };
 		EE82DF9C2E24D5D400EC1AFF /* ChannelCreateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelCreateViewModel.swift; sourceTree = "<group>"; };
 		EE82DF9F2E24D63A00EC1AFF /* ChannelCreateCompleteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChannelCreateCompleteViewModel.swift; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 		EC9959BB2E2518AF001555B1 /* FeedbackWrite */ = {
 			isa = PBXGroup;
 			children = (
+				EE465F6C2E27E8CC0096109A /* FeedbackWriteViewModel.swift */,
 				EE465EEF2E26317A0096109A /* FeedbackWriteView.swift */,
 			);
 			path = FeedbackWrite;
@@ -516,6 +519,7 @@
 				EE856A442E1CD244006820B9 /* Color+Extension.swift in Sources */,
 				EE465F062E27B2420096109A /* InputCodeViewModel.swift in Sources */,
 				EE41FEED2E225A250002E595 /* FirebaseAuthManager.swift in Sources */,
+				EE465F6D2E27E8CD0096109A /* FeedbackWriteViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MainNavigationRoutingView: View {
     
     @State var destination: MainNavigationDestination
+    @EnvironmentObject var router: MainNavigationRouter
     
     var body: some View {
         Group {
@@ -21,7 +22,9 @@ struct MainNavigationRoutingView: View {
             case .feedbackDetail:
                 FeedbackDetailView()
             case .inputCode:
-                InputCodeView()
+                InputCodeView { feedbackChannel in
+                    router.push(to: .feedbackWrite(channel: feedbackChannel))
+                }
             case .feedbackWrite(let feedbackChannel):
                 FeedbackWriteView(feedbackChannel: feedbackChannel)
             case .feedbackWriteComplete:

--- a/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
@@ -22,8 +22,8 @@ struct MainNavigationRoutingView: View {
                 FeedbackDetailView()
             case .inputCode:
                 InputCodeView()
-            case .feedbackWrite:
-                FeedbackWriteView()
+            case .feedbackWrite(let feedbackChannel):
+                FeedbackWriteView(feedbackChannel: feedbackChannel)
             case .feedbackWriteComplete:
                 FeedbackWriteCompleteView()
             case .feedbackChannelCreate:

--- a/GimiFeedback/GimiFeedback/Model/Navigation/NavigationDestination.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/NavigationDestination.swift
@@ -11,7 +11,7 @@ protocol NavigationDestination: Hashable {}
 enum StartNavigationDestination: NavigationDestination {
     case login
     case inputCode
-    case feedbackWrite(code: String)
+    case feedbackWrite(channel: FeedbackChannel)
     case feedbackWriteComplete
 }
 
@@ -21,7 +21,7 @@ enum MainNavigationDestination: NavigationDestination {
     case channelEdit(channelItem: FeedbackChannel)
     case feedbackDetail(feedback: Feedback)
     case inputCode
-    case feedbackWrite(code: String)
+    case feedbackWrite(channel: FeedbackChannel)
     case feedbackWriteComplete
     case feedbackChannelCreate
     case feedbackChannelCreateComplete(channelID: String)

--- a/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
@@ -21,9 +21,9 @@ struct StartNavigationRoutingView: View {
             case .feedbackWriteComplete:
                 // TODO: 피드백 완료 이동
                 EmptyView()
-            case .feedbackWrite:
+            case .feedbackWrite(let feedbackChannel):
                 // TODO: 피드백 생성 이동
-                EmptyView()
+                FeedbackWriteView(feedbackChannel: feedbackChannel)
             }
         }
     }

--- a/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
@@ -10,12 +10,15 @@ import SwiftUI
 struct StartNavigationRoutingView: View {
     
     @State var destination: StartNavigationDestination
+    @EnvironmentObject var router: OnboardingNavigationRouter
     
     var body: some View {
         Group {
             switch destination {
             case .inputCode:
-                InputCodeView()
+                InputCodeView { feedbackChannel in
+                    router.push(to: .feedbackWrite(channel: feedbackChannel))
+                }
             case .login:
                 LoginView()
             case .feedbackWriteComplete:

--- a/GimiFeedback/GimiFeedback/Network/FirestoreManager.swift
+++ b/GimiFeedback/GimiFeedback/Network/FirestoreManager.swift
@@ -42,13 +42,7 @@ final class FirestoreManager {
 
         // 첫 번째 문서를 가져와서 데이터 디코딩
         guard let document = snapshot.documents.first else {
-            throw Error.fetchFailed(
-                underlying: NSError(
-                    domain: "",
-                    code: -1,
-                    userInfo: [NSLocalizedDescriptionKey: "문서가 존재하지 않습니다."]
-                )
-            )
+            throw Error.notfoundCode
         }
 
         guard let jsonData = try? JSONSerialization.data(withJSONObject: document.data()),
@@ -134,6 +128,8 @@ extension FirestoreManager {
         case decodingFailed
         case encodingFailed
         
+        case notfoundCode
+        
         var errorDescription: String? {
             switch self {
             case .addFailed(let error):
@@ -148,6 +144,8 @@ extension FirestoreManager {
                 "데이터를 encoding하는데 실패했습니다"
             case .decodingFailed:
                 "데이터를 decoding하는데 실패했습니다"
+            case .notfoundCode:
+                "해당하는 코드가 없어요. 다시 한번 확인해주세요."
             }
         }
     }

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListView.swift
@@ -45,6 +45,28 @@ struct ChannelListView: View {
                     }
                 }
             }
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button(action: {
+                    router.push(to: .inputCode)
+                }) {
+                    Text("코드 입력하기")
+                        .font(.system(size: 14, weight: .semibold))
+                        .padding(.vertical, 8)
+                        .padding(.horizontal, 16)
+                        .background(Color.green.opacity(0.2))
+                        .foregroundColor(.green)
+                        .clipShape(Capsule())
+                }
+
+                Button(action: {
+                    // TODO: Profile 만들기
+                }) {
+                    Image(systemName: "person.crop.circle.fill")
+                        .resizable()
+                        .frame(width: 32, height: 32)
+                        .foregroundColor(.green)
+                }
+            }
         }
         .toolbarBackground(Color.gray.opacity(0.1), for: .bottomBar)
         .toolbarBackground(.visible, for: .bottomBar)

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
@@ -8,11 +8,28 @@
 import SwiftUI
 
 struct FeedbackWriteView: View {
+    @StateObject var viewModel: FeedbackWriteViewModel
+    
+    init(feedbackChannel: FeedbackChannel) {
+        _viewModel = StateObject(
+            wrappedValue: .init(
+                feedbackChannel: feedbackChannel
+            )
+        )
+    }
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text(viewModel.feedbackChannel.channelTitle)
+        Text(viewModel.feedbackChannel.content)
     }
 }
 
 #Preview {
-    FeedbackWriteView()
+    let feedbackChannel = FeedbackChannel(
+        userID: "Test",
+        channelTitle: "Test",
+        content: "Test"
+    )
+    
+    FeedbackWriteView(feedbackChannel: feedbackChannel)
 }

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteViewModel.swift
@@ -1,0 +1,26 @@
+//
+//  FeedbackWriteViewModel.swift
+//  GimiFeedback
+//
+//  Created by 김민석 on 7/16/25.
+//
+
+final class FeedbackWriteViewModel: ViewModelable {
+    enum Action {
+        case feedbackWrite
+    }
+    
+    let feedbackChannel: FeedbackChannel
+    
+    init(feedbackChannel: FeedbackChannel) {
+        self.feedbackChannel = feedbackChannel
+    }
+    
+    func send(_ action: Action) {
+        switch action {
+        case .feedbackWrite:
+            print("Write")
+        }
+    }
+    
+}

--- a/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeView.swift
@@ -8,8 +8,39 @@
 import SwiftUI
 
 struct InputCodeView: View {
+    @StateObject var viewModel: InputCodeViewModel
+    
+    init() {
+        _viewModel = StateObject(wrappedValue: .init())
+    }
+    
     var body: some View {
-        Text("Input Code View")
+        VStack(alignment: .leading) {
+            Text("코드 입력하기")
+            
+            TextField("받은 코드를 붙여 넣어주세요", text: $viewModel.code)
+                .padding(.vertical, 8)
+                .overlay(
+                    Rectangle()
+                        .frame(height: 1)
+                        .foregroundColor(.gray),
+                    alignment: .bottom
+                )
+            
+            Spacer()
+            
+            Button(action: {
+                viewModel.send(.verifyCode)
+            }, label: {
+                Text("완료하기")
+                    .font(Font.system(size: 20, weight: .bold))
+                    .foregroundColor(.white)
+                    .frame(maxWidth: .infinity, maxHeight: 66)
+                    .background(Color.black)
+                    .cornerRadius(20)
+            })
+            .disabled(viewModel.code.isEmpty)
+        }.padding()
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeView.swift
@@ -58,6 +58,12 @@ struct InputCodeView: View {
                 onComplete(feedbackChannel)
             }
         }
+        .onChange(of: viewModel.errorMessage) { newValue in
+            if newValue != nil {
+                let generator = UINotificationFeedbackGenerator()
+                generator.notificationOccurred(.error)
+            }
+        }
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeView.swift
@@ -9,10 +9,11 @@ import SwiftUI
 
 struct InputCodeView: View {
     @StateObject var viewModel: InputCodeViewModel
-    @EnvironmentObject var router: MainNavigationRouter
+    var onComplete: (FeedbackChannel) -> Void
     
-    init() {
+    init(onComplete: @escaping (FeedbackChannel) -> Void) {
         _viewModel = StateObject(wrappedValue: .init())
+        self.onComplete = onComplete
     }
     
     var body: some View {
@@ -54,12 +55,14 @@ struct InputCodeView: View {
         .padding()
         .onChange(of: viewModel.feedbackChannel) { newValue in
             if let feedbackChannel = newValue {
-                router.push(to: .feedbackWrite(channel: feedbackChannel))
+                onComplete(feedbackChannel)
             }
         }
     }
 }
 
 #Preview {
-    InputCodeView()
+    InputCodeView { feedbackChannel in
+        print("Test - \(feedbackChannel)")
+    }
 }

--- a/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct InputCodeView: View {
     @StateObject var viewModel: InputCodeViewModel
+    @EnvironmentObject var router: MainNavigationRouter
     
     init() {
         _viewModel = StateObject(wrappedValue: .init())
@@ -27,6 +28,15 @@ struct InputCodeView: View {
                     alignment: .bottom
                 )
             
+            if let errorMessage = viewModel.errorMessage {
+                HStack(spacing: 4) {
+                    Image(systemName: "xmark.circle")
+                    Text(errorMessage)
+                }
+                .foregroundColor(.red)
+                .padding(.top, 4)
+            }
+            
             Spacer()
             
             Button(action: {
@@ -40,7 +50,13 @@ struct InputCodeView: View {
                     .cornerRadius(20)
             })
             .disabled(viewModel.code.isEmpty)
-        }.padding()
+        }
+        .padding()
+        .onChange(of: viewModel.feedbackChannel) { newValue in
+            if let feedbackChannel = newValue {
+                router.push(to: .feedbackWrite(channel: feedbackChannel))
+            }
+        }
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeViewModel.swift
@@ -34,6 +34,7 @@ final class InputCodeViewModel: ViewModelable {
                 }
             } catch {
                 print("코드 검증 실패: \(error.localizedDescription)")
+                errorMessage = error.localizedDescription
             }
         }
     }

--- a/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  InputCodeViewModel.swift
+//  GimiFeedback
+//
+//  Created by 김민석 on 7/16/25.
+//
+
+import Foundation
+
+final class InputCodeViewModel: ViewModelable {
+    enum Action {
+        case verifyCode
+    }
+    
+    @Published var code: String = ""
+    @Published private(set) var feedbackChannel: FeedbackChannel?
+    @Published private(set) var errorMessage: String?
+    
+    func send(_ action: Action) {
+        switch action {
+        case .verifyCode:
+            verifyCode()
+        }
+    }
+    
+    private func verifyCode() {
+        Task {
+            do {
+                if let getFeedbackChannel: FeedbackChannel = try await
+                    FirestoreManager.shared.get(
+                        code, collectionType: .feedbackChannel
+                ) {
+                    feedbackChannel = getFeedbackChannel
+                }
+            } catch {
+                print("코드 검증 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+}

--- a/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputCode/InputCodeViewModel.swift
@@ -26,6 +26,8 @@ final class InputCodeViewModel: ViewModelable {
     private func verifyCode() {
         Task {
             do {
+                errorMessage = nil
+                
                 if let getFeedbackChannel: FeedbackChannel = try await
                     FirestoreManager.shared.get(
                         code, collectionType: .feedbackChannel


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
피드백 코드 입력 화면과 로직을 구현했습니다.
- 피드백 코드 입력 화면 구현
- 로그인, 메인 화면에서 올 수 있도록 구현
- 코드 검증 후 에러 반환
- 코드가 맞으면 Feedback Write로 이동

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
|로그인 전|로그인 후|
|---|---|
|![Simulator Screen Recording - iPhone 16 Pro - 2025-07-16 at 23 57 50](https://github.com/user-attachments/assets/0d77d944-1e19-40e0-b485-f96bdc00c4bc)|![Simulator Screen Recording - iPhone 16 Pro - 2025-07-16 at 23 58 27](https://github.com/user-attachments/assets/fbf0a5a8-8021-42c8-ac7b-5a12137ea8a0)|

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
코드 입력 부분 Navigation을 잘 확인해주세요!!

`InputCodeView`에서
Router를 `EnvironmentObject`로 하려고 하니까
InputCodeView에서 `어떤 라우터를 쓸지 몰라서 에러`가 나왔습니다!

해결법

1. Completion으로 전달
2. 해당하는 RoutingView에서 받기
3. RoutingView에서 FeedbackWriteView로 push해주기!

이렇게 해서 Completion으로 화면 이동이 일어나도록 했습니다!
