### PR TITLE
피드백 작성 화면 구현(TextFeild, Button)(#30)

### DIFF
--- a/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
+++ b/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
@@ -673,7 +673,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -710,7 +710,7 @@
 				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/GimiFeedback/GimiFeedback/Model/FeedbackContentType.swift
+++ b/GimiFeedback/GimiFeedback/Model/FeedbackContentType.swift
@@ -11,5 +11,31 @@ enum FeedbackContentType: Int, Codable, Identifiable, CaseIterable {
     case `try`
     case other
     
+    var title: String {
+        switch self {
+        case .keep:
+            "Keep"
+        case .problem:
+            "Prolem"
+        case .try:
+            "Try"
+        case .other:
+            "추가로 할말"
+        }
+    }
+    
+    var content: String {
+        switch self {
+        case .keep:
+            "계속해서 지속하면 좋을 점을 작성해주세요"
+        case .problem:
+            "아직 개선해야 될 문제인 점을 적어주세요"
+        case .try:
+            "해당 내용들로 어떤 행동을 해야할지 적어주세요"
+        case .other:
+            "마지막으로 하고 싶은 말을 적어주세요"
+        }
+    }
+    
     var id: Int { rawValue }
 }

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
@@ -55,15 +55,23 @@ struct FeedbackWriteView: View {
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .frame(height: 64)
-                        .background(viewModel.canCreate ? Color.black : Color.gray.opacity(0.5))
+                        .background(!viewModel.canCreate ? Color.black : Color.gray.opacity(0.5))
                         .cornerRadius(16)
                 })
-                .disabled(viewModel.canCreate)
+                .disabled(!viewModel.canCreate)
             }
         }
         .contentMargins(.horizontal, 20, for: .scrollContent)
         .navigationTitle("피드백 작성하기")
         .navigationBarTitleDisplayMode(.inline)
+        .alert("작성 완료하기", isPresented: $isShowCreateAlert) {
+            Button("취소", role: .cancel) { }
+            Button("확인") {
+                viewModel.send(.feedbackWrite)
+            }
+        } message: {
+            Text("이대로 피드백을 전송하시겠습니까?\n이 작업은 취소할 수 없습니다.")
+        }
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
@@ -86,7 +86,8 @@ extension FeedbackWriteView {
                 Text(contentType.title)
                 Text(contentType.content)
                 ForEach(content.indices, id: \.self) { index in
-                    TextField("", text: $content[index])
+                    TextEditor(text: $content[index])
+                        .scrollContentBackground(.hidden)
                         .frame(height: 102)
                         .padding()
                         .background(Color(UIColor.systemGray6))
@@ -114,8 +115,8 @@ extension FeedbackWriteView {
 #Preview {
     let feedbackChannel = FeedbackChannel(
         userID: "Test",
-        channelTitle: "Test",
-        content: "Test"
+        channelTitle: "Test용 피드백입니다.",
+        content: "Test용 내용입니다"
     )
     
     FeedbackWriteView(feedbackChannel: feedbackChannel)

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
@@ -52,21 +52,26 @@ extension FeedbackWriteView {
         var body: some View {
             Text(contentType.title)
             Text(contentType.content)
-            TextField("", text: $content[0])
-                .frame(height: 102)
-                .padding()
-                .background(Color(UIColor.systemGray6))
-                .cornerRadius(5)
+            ForEach(content.indices, id: \.self) { index in
+                TextField("", text: $content[index])
+                    .frame(height: 102)
+                    .padding()
+                    .background(Color(UIColor.systemGray6))
+                    .cornerRadius(5)
+            }
             
-            Button {
-                // TODO: 항목 추가하기 버튼 동작
-            } label: {
-                Text("+ 항목 추가하기")
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 56)
-                    .foregroundColor(.black)
-                    .background(.gray)
-                    .cornerRadius(12)
+            if content.count < 3 {
+                Button {
+                    content.append("")
+                } label: {
+                    Text("+ 항목 추가하기")
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 56)
+                        .foregroundColor(.black)
+                        .background(Color.gray.opacity(0.3))
+                        .cornerRadius(12)
+                }
+                .padding(.top, 8)
             }
         }
     }

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
@@ -19,8 +19,56 @@ struct FeedbackWriteView: View {
     }
     
     var body: some View {
-        Text(viewModel.feedbackChannel.channelTitle)
-        Text(viewModel.feedbackChannel.content)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text(viewModel.feedbackChannel.channelTitle)
+                Text(viewModel.feedbackChannel.content)
+                
+                Text("닉네임")
+                Text("받는 사람에게 보여지는 닉네임입니다.")
+                TextField("", text: $viewModel.nickName)
+                    .padding()
+                    .background(Color(UIColor.systemGray6))
+                    .cornerRadius(5)
+                
+                FeedbackContentView(content: $viewModel.keeps, contentType: .keep)
+                FeedbackContentView(content: $viewModel.problems, contentType: .problem)
+                FeedbackContentView(content: $viewModel.trys, contentType: .try)
+                FeedbackContentView(content: $viewModel.others, contentType: .other)
+            }
+        }
+        .padding()
+        .navigationTitle("피드백 작성하기")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+extension FeedbackWriteView {
+    struct FeedbackContentView: View {
+        @Binding var content: [String]
+        
+        var contentType: FeedbackContentType
+        
+        var body: some View {
+            Text(contentType.title)
+            Text(contentType.content)
+            TextField("", text: $content[0])
+                .frame(height: 102)
+                .padding()
+                .background(Color(UIColor.systemGray6))
+                .cornerRadius(5)
+            
+            Button {
+                // TODO: 항목 추가하기 버튼 동작
+            } label: {
+                Text("+ 항목 추가하기")
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 56)
+                    .foregroundColor(.black)
+                    .background(.gray)
+                    .cornerRadius(12)
+            }
+        }
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct FeedbackWriteView: View {
     @StateObject var viewModel: FeedbackWriteViewModel
+    @State private var isShowCreateAlert: Bool = false
     
     init(feedbackChannel: FeedbackChannel) {
         _viewModel = StateObject(
@@ -20,24 +21,47 @@ struct FeedbackWriteView: View {
     
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                Text(viewModel.feedbackChannel.channelTitle)
-                Text(viewModel.feedbackChannel.content)
+            VStack(alignment: .leading, spacing: 40) {
+                VStack {
+                    Text(viewModel.feedbackChannel.channelTitle)
+                    Text(viewModel.feedbackChannel.content)
+                }
                 
-                Text("닉네임")
-                Text("받는 사람에게 보여지는 닉네임입니다.")
-                TextField("", text: $viewModel.nickName)
-                    .padding()
-                    .background(Color(UIColor.systemGray6))
-                    .cornerRadius(5)
+                Rectangle()
+                    .fill(Color.gray)
+                    .frame(height: 8)
+                    .frame(maxWidth: .infinity)
+                    .padding(-20)
+                
+                VStack(alignment: .leading, spacing: 10) {
+                    Text("닉네임")
+                    Text("받는 사람에게 보여지는 닉네임입니다.")
+                    TextField("", text: $viewModel.nickName)
+                        .padding()
+                        .background(Color(UIColor.systemGray6))
+                        .cornerRadius(5)
+                }
                 
                 FeedbackContentView(content: $viewModel.keeps, contentType: .keep)
                 FeedbackContentView(content: $viewModel.problems, contentType: .problem)
                 FeedbackContentView(content: $viewModel.trys, contentType: .try)
                 FeedbackContentView(content: $viewModel.others, contentType: .other)
+                
+                Button(action: {
+                    isShowCreateAlert = true
+                }, label: {
+                    Text("완료하기")
+                        .font(Font.system(size: 20, weight: .bold))
+                        .foregroundColor(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 64)
+                        .background(viewModel.canCreate ? Color.black : Color.gray.opacity(0.5))
+                        .cornerRadius(16)
+                })
+                .disabled(viewModel.canCreate)
             }
         }
-        .padding()
+        .contentMargins(.horizontal, 20, for: .scrollContent)
         .navigationTitle("피드백 작성하기")
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -50,28 +74,30 @@ extension FeedbackWriteView {
         var contentType: FeedbackContentType
         
         var body: some View {
-            Text(contentType.title)
-            Text(contentType.content)
-            ForEach(content.indices, id: \.self) { index in
-                TextField("", text: $content[index])
-                    .frame(height: 102)
-                    .padding()
-                    .background(Color(UIColor.systemGray6))
-                    .cornerRadius(5)
-            }
-            
-            if content.count < 3 {
-                Button {
-                    content.append("")
-                } label: {
-                    Text("+ 항목 추가하기")
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 56)
-                        .foregroundColor(.black)
-                        .background(Color.gray.opacity(0.3))
-                        .cornerRadius(12)
+            VStack(alignment: .leading, spacing: 10) {
+                Text(contentType.title)
+                Text(contentType.content)
+                ForEach(content.indices, id: \.self) { index in
+                    TextField("", text: $content[index])
+                        .frame(height: 102)
+                        .padding()
+                        .background(Color(UIColor.systemGray6))
+                        .cornerRadius(5)
                 }
-                .padding(.top, 8)
+                
+                if content.count < 3 {
+                    Button {
+                        content.append("")
+                    } label: {
+                        Text("+ 항목 추가하기")
+                            .frame(maxWidth: .infinity)
+                            .frame(height: 56)
+                            .foregroundColor(.black)
+                            .background(Color.gray.opacity(0.3))
+                            .cornerRadius(12)
+                    }
+                    .padding(.top, 8)
+                }
             }
         }
     }

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteViewModel.swift
@@ -19,6 +19,14 @@ final class FeedbackWriteViewModel: ViewModelable {
     @Published var trys: [String] = [""]
     @Published var others: [String] = [""]
     
+    var canCreate: Bool {
+        let isNickNameFilled = !nickName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let isAnyFieldFilled = keeps.contains(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) ||
+                               problems.contains(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) ||
+                               trys.contains(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+        return isNickNameFilled && isAnyFieldFilled
+    }
+    
     init(feedbackChannel: FeedbackChannel) {
         self.feedbackChannel = feedbackChannel
     }

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteViewModel.swift
@@ -5,12 +5,19 @@
 //  Created by 김민석 on 7/16/25.
 //
 
+import Foundation
+
 final class FeedbackWriteViewModel: ViewModelable {
     enum Action {
         case feedbackWrite
     }
     
     let feedbackChannel: FeedbackChannel
+    @Published var nickName: String = ""
+    @Published var keeps: [String] = [""]
+    @Published var problems: [String] = [""]
+    @Published var trys: [String] = [""]
+    @Published var others: [String] = [""]
     
     init(feedbackChannel: FeedbackChannel) {
         self.feedbackChannel = feedbackChannel


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
피드백 작성 View를 구현했습니다!
- 피드백 채널 제목과 내용 보임
- 피드백 작성 TextFeild 구현
- TextFeild 추가 버튼 기능 구현
- 데이터에 따른 완료버튼 로직 구현

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-17 at 12 18 01](https://github.com/user-attachments/assets/a682e25d-6cb6-4c8a-9a4e-90ca29999915)


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
Scroll Padding 때문에 `contentMargins`이걸 넣었는데
이 부분이 17버전 이상이라 상관 없다면 Target 버전을 17로 올리자고 제안해봅니다!
