### PR TITLE
닉네임 입력 화면 구현 및 분기 처리 구현(#107)

### DIFF
--- a/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
+++ b/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 		EE3756A32E1E602F009AD262 /* EntityRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3756A22E1E602C009AD262 /* EntityRepresentable.swift */; };
 		EE3756A52E1E6062009AD262 /* CollectionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE3756A42E1E6060009AD262 /* CollectionType.swift */; };
 		EE37582C2E1F80F3009AD262 /* Encodable+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE37582B2E1F80F1009AD262 /* Encodable+Extension.swift */; };
-		EE41FD7D2E223D050002E595 /* NickNameInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41FD7C2E223CFD0002E595 /* NickNameInputView.swift */; };
+		EE41FD7D2E223D050002E595 /* InputNickNameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41FD7C2E223CFD0002E595 /* InputNickNameView.swift */; };
 		EE41FD822E223D720002E595 /* InputCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE41FD812E223D720002E595 /* InputCodeView.swift */; };
 		EE41FEDC2E2250DF0002E595 /* KakaoSDKAuth in Frameworks */ = {isa = PBXBuildFile; productRef = EE41FEDB2E2250DF0002E595 /* KakaoSDKAuth */; };
 		EE41FEDE2E2250DF0002E595 /* KakaoSDKCommon in Frameworks */ = {isa = PBXBuildFile; productRef = EE41FEDD2E2250DF0002E595 /* KakaoSDKCommon */; };
@@ -107,7 +107,7 @@
 		EE3756A22E1E602C009AD262 /* EntityRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityRepresentable.swift; sourceTree = "<group>"; };
 		EE3756A42E1E6060009AD262 /* CollectionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionType.swift; sourceTree = "<group>"; };
 		EE37582B2E1F80F1009AD262 /* Encodable+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Extension.swift"; sourceTree = "<group>"; };
-		EE41FD7C2E223CFD0002E595 /* NickNameInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NickNameInputView.swift; sourceTree = "<group>"; };
+		EE41FD7C2E223CFD0002E595 /* InputNickNameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputNickNameView.swift; sourceTree = "<group>"; };
 		EE41FD812E223D720002E595 /* InputCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputCodeView.swift; sourceTree = "<group>"; };
 		EE41FEE12E22511D0002E595 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EE41FEE42E2256280002E595 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -383,6 +383,7 @@
 				EE82DF9E2E24D5FC00EC1AFF /* ChannelCreateComplete */,
 				EC9959B12E24E646001555B1 /* ChannelDetail */,
 				EC9959B52E251368001555B1 /* ChannelEdit */,
+				EEC04A002E326B3500918BAA /* InputNickName */,
 				EE41FD7E2E223D180002E595 /* InputCode */,
 				EC9959BB2E2518AF001555B1 /* FeedbackWrite */,
 				EC9959BE2E2518BE001555B1 /* FeedbackWriteComplete */,
@@ -468,7 +469,6 @@
 			isa = PBXGroup;
 			children = (
 				EE856A5A2E1CEA98006820B9 /* StartView.swift */,
-				EE41FD7C2E223CFD0002E595 /* NickNameInputView.swift */,
 				EE41FEE82E2259310002E595 /* UserViewModel.swift */,
 			);
 			path = Start;
@@ -513,6 +513,14 @@
 				EEC048702E2E1E6100918BAA /* CustomNaviModifier.swift */,
 			);
 			path = Components;
+			sourceTree = "<group>";
+		};
+		EEC04A002E326B3500918BAA /* InputNickName */ = {
+			isa = PBXGroup;
+			children = (
+				EE41FD7C2E223CFD0002E595 /* InputNickNameView.swift */,
+			);
+			path = InputNickName;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -629,7 +637,7 @@
 				EEC048752E2E916100918BAA /* SpeechView.swift in Sources */,
 				EEC0471A2E2E1D3B00918BAA /* GimiButtonStyle.swift in Sources */,
 				EE41FEE72E22572C0002E595 /* Bundle+Extension.swift in Sources */,
-				EE41FD7D2E223D050002E595 /* NickNameInputView.swift in Sources */,
+				EE41FD7D2E223D050002E595 /* InputNickNameView.swift in Sources */,
 				EE465EFC2E2650970096109A /* MainView.swift in Sources */,
 				EEB902CF2E260C7100C71DF9 /* StartNavigationRoutingView.swift in Sources */,
 				EE465EF22E2631840096109A /* FeedbackWriteCompleteView.swift in Sources */,

--- a/GimiFeedback/GimiFeedback/App/GimiFeedbackApp.swift
+++ b/GimiFeedback/GimiFeedback/App/GimiFeedbackApp.swift
@@ -32,8 +32,6 @@ struct GimiFeedbackApp: App {
                                 notificationRouter.send(.saveUserInfo(userInfo: userInfo))
                             }
                         }
-                } else if userViewModel.saveUserNickName.isEmpty && FirebaseAuthManager.currentUser {
-                    NickNameInputView()
                 } else {
                     StartView()
                         .onOpenURL { url in

--- a/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
@@ -25,8 +25,10 @@ struct MainNavigationRoutingView: View {
                 FeedbackDetailView(feedbackItem: feedbackItem)
             case .inputCode:
                 InputCodeView { feedbackChannel in
-                    router.push(to: .feedbackWrite(channel: feedbackChannel))
+                    router.push(to: .inputNickName)
                 }
+            case .inputNickName:
+                InputNickNameView(scene: .main)
             case .feedbackWrite(let feedbackChannel):
                 FeedbackWriteView(feedbackChannel: feedbackChannel) {
                     router.push(to: .feedbackWriteComplete)

--- a/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
@@ -25,10 +25,8 @@ struct MainNavigationRoutingView: View {
                 FeedbackDetailView(feedbackItem: feedbackItem)
             case .inputCode:
                 InputCodeView { feedbackChannel in
-                    router.push(to: .inputNickName)
+                    router.push(to: .feedbackWrite(channel: feedbackChannel))
                 }
-            case .inputNickName:
-                InputNickNameView(scene: .main)
             case .feedbackWrite(let feedbackChannel):
                 FeedbackWriteView(feedbackChannel: feedbackChannel) {
                     router.push(to: .feedbackWriteComplete)

--- a/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/MainNavigationRoutingView.swift
@@ -11,6 +11,7 @@ struct MainNavigationRoutingView: View {
     
     @State var destination: MainNavigationDestination
     @EnvironmentObject var router: MainNavigationRouter
+    @EnvironmentObject var userViewModel: UserViewModel
     
     var body: some View {
         Group {
@@ -28,7 +29,10 @@ struct MainNavigationRoutingView: View {
                     router.push(to: .feedbackWrite(channel: feedbackChannel))
                 }
             case .feedbackWrite(let feedbackChannel):
-                FeedbackWriteView(feedbackChannel: feedbackChannel) {
+                FeedbackWriteView(
+                    feedbackChannel: feedbackChannel,
+                    inputNickName: userViewModel.saveUserNickName
+                ) {
                     router.push(to: .feedbackWriteComplete)
                 }
             case .feedbackWriteComplete:

--- a/GimiFeedback/GimiFeedback/Model/Navigation/NavigationDestination.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/NavigationDestination.swift
@@ -9,7 +9,7 @@ protocol NavigationDestination: Hashable {}
 
 // MARK: Onboarding
 enum StartNavigationDestination: NavigationDestination {
-    case nickNameInput
+    case inputNickName
     case inputCode
     case feedbackWrite(channel: FeedbackChannel)
     case feedbackWriteComplete
@@ -22,6 +22,7 @@ enum MainNavigationDestination: NavigationDestination {
     case channelEdit(channelItem: FeedbackChannel)
     case feedbackDetail(feedback: Feedback)
     case inputCode
+    case inputNickName
     case feedbackWrite(channel: FeedbackChannel)
     case feedbackWriteComplete
     case feedbackChannelCreate

--- a/GimiFeedback/GimiFeedback/Model/Navigation/NavigationDestination.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/NavigationDestination.swift
@@ -22,7 +22,6 @@ enum MainNavigationDestination: NavigationDestination {
     case channelEdit(channelItem: FeedbackChannel)
     case feedbackDetail(feedback: Feedback)
     case inputCode
-    case inputNickName
     case feedbackWrite(channel: FeedbackChannel)
     case feedbackWriteComplete
     case feedbackChannelCreate

--- a/GimiFeedback/GimiFeedback/Model/Navigation/NavigationDestination.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/NavigationDestination.swift
@@ -9,9 +9,10 @@ protocol NavigationDestination: Hashable {}
 
 // MARK: Onboarding
 enum StartNavigationDestination: NavigationDestination {
-    case inputNickName
+    case startUserinputNickName
     case inputCode
-    case feedbackWrite(channel: FeedbackChannel)
+    case feedbackWriteInputNickName(channel: FeedbackChannel)
+    case feedbackWrite(channel: FeedbackChannel, inputNickName: String)
     case feedbackWriteComplete
 }
 

--- a/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
@@ -11,6 +11,7 @@ struct StartNavigationRoutingView: View {
     
     @State var destination: StartNavigationDestination
     @EnvironmentObject var router: OnboardingNavigationRouter
+    @EnvironmentObject var userViewModel: UserViewModel
     
     var body: some View {
         Group {
@@ -20,7 +21,9 @@ struct StartNavigationRoutingView: View {
                     router.push(to: .feedbackWrite(channel: feedbackChannel))
                 }
             case .inputNickName:
-                InputNickNameView(scene: .start)
+                InputNickNameView(scene: .start) { inputNickName in
+                    userViewModel.send(.nickNameSave(inputNickName))
+                }
             case .feedbackWrite(let feedbackChannel):
                 FeedbackWriteView(feedbackChannel: feedbackChannel) {
                     router.push(to: .feedbackWriteComplete)

--- a/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
@@ -19,8 +19,8 @@ struct StartNavigationRoutingView: View {
                 InputCodeView { feedbackChannel in
                     router.push(to: .feedbackWrite(channel: feedbackChannel))
                 }
-            case .nickNameInput:
-                NickNameInputView()
+            case .inputNickName:
+                InputNickNameView(scene: .start)
             case .feedbackWrite(let feedbackChannel):
                 FeedbackWriteView(feedbackChannel: feedbackChannel) {
                     router.push(to: .feedbackWriteComplete)

--- a/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
@@ -32,7 +32,10 @@ struct StartNavigationRoutingView: View {
                     ))
                 }
             case let .feedbackWrite(feedbackChannel, nickName):
-                FeedbackWriteView(feedbackChannel: feedbackChannel) {
+                FeedbackWriteView(
+                    feedbackChannel: feedbackChannel,
+                    inputNickName: nickName
+                ) {
                     router.push(to: .feedbackWriteComplete)
                 }
 

--- a/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
+++ b/GimiFeedback/GimiFeedback/Model/Navigation/StartNavigationRoutingView.swift
@@ -16,18 +16,26 @@ struct StartNavigationRoutingView: View {
     var body: some View {
         Group {
             switch destination {
-            case .inputCode:
-                InputCodeView { feedbackChannel in
-                    router.push(to: .feedbackWrite(channel: feedbackChannel))
-                }
-            case .inputNickName:
-                InputNickNameView(scene: .start) { inputNickName in
+            case .startUserinputNickName:
+                InputNickNameView(mode: .startUserInput) { inputNickName in
                     userViewModel.send(.nickNameSave(inputNickName))
                 }
-            case .feedbackWrite(let feedbackChannel):
+            case .inputCode:
+                InputCodeView { feedbackChannel in
+                    router.push(to: .feedbackWriteInputNickName(channel: feedbackChannel))
+                }
+            case .feedbackWriteInputNickName(let channel):
+                InputNickNameView(mode: .feedbackWriteInput) { inputNickName in
+                    router.push(to: .feedbackWrite(
+                        channel: channel,
+                        inputNickName: inputNickName
+                    ))
+                }
+            case let .feedbackWrite(feedbackChannel, nickName):
                 FeedbackWriteView(feedbackChannel: feedbackChannel) {
                     router.push(to: .feedbackWriteComplete)
                 }
+
             case .feedbackWriteComplete:
                 FeedbackWriteCompleteView()
             }

--- a/GimiFeedback/GimiFeedback/Model/User.swift
+++ b/GimiFeedback/GimiFeedback/Model/User.swift
@@ -9,18 +9,15 @@ import Foundation
 
 struct User: Codable, Hashable {
     let id: String
-    let nickName: String
     let fcmToken: String
     let badgeCount: Int
     
     init(
         userID: String,
-        nickName: String,
         fcmToken: String,
         badgeCount: Int
     ) {
         self.id = userID
-        self.nickName = nickName
         self.fcmToken = fcmToken
         self.badgeCount = badgeCount
     }

--- a/GimiFeedback/GimiFeedback/Network/FirebaseAuthManager.swift
+++ b/GimiFeedback/GimiFeedback/Network/FirebaseAuthManager.swift
@@ -22,8 +22,15 @@ final class FirebaseAuthManager {
     static var currentUserID: String {
         return Auth.auth().currentUser?.uid ?? ""
     }
-    
-    private init() {}
+
+    private var authStateDidChangeHandle: AuthStateDidChangeListenerHandle?
+
+    private init() {
+        authStateDidChangeHandle = Auth.auth().addStateDidChangeListener { _, user in
+            print("Firebase auth state changed. user: \(user?.uid ?? "nil")")
+            NotificationCenter.default.post(name: .firebaseAuthStateChanged, object: nil)
+        }
+    }
     
     func emailSignUpOrLogin(email: String, password: String) async throws {
         do {
@@ -44,10 +51,11 @@ final class FirebaseAuthManager {
         try Auth.auth().signOut()
     }
     
-    func saveUserNickName(nickName: String) async throws{
+    func saveUserNickName(nickName: String) async throws {
         let changeRequest = Auth.auth().currentUser?.createProfileChangeRequest()
         changeRequest?.displayName = nickName
         try await changeRequest?.commitChanges()
+        NotificationCenter.default.post(name: .firebaseAuthStateChanged, object: nil)
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteView.swift
@@ -14,10 +14,14 @@ struct FeedbackWriteView: View {
     
     init(
         feedbackChannel: FeedbackChannel,
+        inputNickName: String,
         onComplete: @escaping () -> Void
     ) {
         _viewModel = StateObject(
-            wrappedValue: .init(feedbackChannel: feedbackChannel)
+            wrappedValue: .init(
+                feedbackChannel: feedbackChannel,
+                nickName: inputNickName
+            )
         )
         self.onComplete = onComplete
     }
@@ -38,11 +42,7 @@ struct FeedbackWriteView: View {
                 
                 VStack(alignment: .leading, spacing: 10) {
                     Text("닉네임")
-                    Text("받는 사람에게 보여지는 닉네임입니다.")
-                    TextField("", text: $viewModel.nickName)
-                        .padding()
-                        .background(Color(UIColor.systemGray6))
-                        .cornerRadius(5)
+                    Text(viewModel.nickName)
                 }
                 
                 FeedbackContentView(content: $viewModel.keeps, contentType: .typeContinue)
@@ -126,7 +126,7 @@ extension FeedbackWriteView {
         content: "Test용 내용입니다"
     )
     
-    FeedbackWriteView(feedbackChannel: feedbackChannel) {
+    FeedbackWriteView(feedbackChannel: feedbackChannel, inputNickName: "test") {
         print("Test")
     }
 }

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackWrite/FeedbackWriteViewModel.swift
@@ -13,7 +13,7 @@ final class FeedbackWriteViewModel: ViewModelable {
     }
     
     let feedbackChannel: FeedbackChannel
-    @Published var nickName: String = ""
+    let nickName: String
     @Published var keeps: [String] = [""]
     @Published var problems: [String] = [""]
     @Published var trys: [String] = [""]
@@ -25,20 +25,19 @@ final class FeedbackWriteViewModel: ViewModelable {
     private(set) var createdFeedback: Feedback?
     
     var canCreate: Bool {
-        let isNickNameFilled = !nickName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        let isAnyFieldFilled = keeps.contains(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) ||
+        let isAnyFieldFilled =
+        keeps.contains(
+            where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty}) ||
         problems.contains(
-            where: {
-                !$0.trimmingCharacters(
-                    in: .whitespacesAndNewlines
-                ).isEmpty
-            }) ||
-                               trys.contains(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
-        return isNickNameFilled && isAnyFieldFilled
+            where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty}) ||
+        trys.contains(
+            where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+        return isAnyFieldFilled
     }
     
-    init(feedbackChannel: FeedbackChannel) {
+    init(feedbackChannel: FeedbackChannel, nickName: String) {
         self.feedbackChannel = feedbackChannel
+        self.nickName = nickName
     }
     
     func send(_ action: Action) {

--- a/GimiFeedback/GimiFeedback/Presentation/InputNickName/InputNickNameView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputNickName/InputNickNameView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct InputNickNameView: View {
     
     @State var inputNickName: String = ""
-    let scene: NickNameInputScene
+    let mode: NickNameInputMode
     
     var onComplete: (String) -> Void
     
@@ -19,7 +19,7 @@ struct InputNickNameView: View {
             Text("닉네임")
                 .font(.title1)
             
-            Text(scene.subTitle)
+            Text(mode.subTitle)
                 .font(.footnote)
                 .foregroundStyle(.gray400)
             
@@ -28,7 +28,7 @@ struct InputNickNameView: View {
             
             Spacer()
             
-            Button(scene.buttonText) {
+            Button(mode.buttonText) {
                 onComplete(inputNickName)
             }
             .buttonStyle(.gimiPrimary)
@@ -40,24 +40,24 @@ struct InputNickNameView: View {
     }
 }
 
-enum NickNameInputScene {
-    case start
-    case main
+enum NickNameInputMode {
+    case startUserInput
+    case feedbackWriteInput
     
     var subTitle: String {
         switch self {
-        case .start:
+        case .startUserInput:
             "피드백을 요청할때 상대에게 보여질 닉네임이에요"
-        case .main:
+        case .feedbackWriteInput:
             "받는 사람에게 보일 닉네임이에요"
         }
     }
     
     var buttonText: String {
         switch self {
-        case .start:
+        case .startUserInput:
             "시작하기"
-        case .main:
+        case .feedbackWriteInput:
             "다음"
         }
     }
@@ -66,6 +66,6 @@ enum NickNameInputScene {
 #Preview {
     let userViewModel = UserViewModel()
     
-    InputNickNameView(scene: .main) { _ in }
+    InputNickNameView(mode: .feedbackWriteInput) { _ in }
         .environmentObject(userViewModel)
 }

--- a/GimiFeedback/GimiFeedback/Presentation/InputNickName/InputNickNameView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputNickName/InputNickNameView.swift
@@ -34,9 +34,9 @@ struct InputNickNameView: View {
             .buttonStyle(.gimiPrimary)
             .disabled(inputNickName.isEmpty)
         }
-        .navigationBarBackButtonHidden()
         .padding()
-        .padding(.top, 44)
+        .navigationBarBackButtonHidden(mode == .startUserInput)
+        .padding(.top, mode == .startUserInput ? 44 : 0)
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/InputNickName/InputNickNameView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputNickName/InputNickNameView.swift
@@ -8,8 +8,11 @@
 import SwiftUI
 
 struct InputNickNameView: View {
-    @EnvironmentObject var viewModel: UserViewModel
+    
+    @State var inputNickName: String = ""
     let scene: NickNameInputScene
+    
+    var onComplete: (String) -> Void
     
     var body: some View {
         VStack(alignment: .leading) {
@@ -20,16 +23,16 @@ struct InputNickNameView: View {
                 .font(.footnote)
                 .foregroundStyle(.gray400)
             
-            TextField("", text: $viewModel.inputNickName)
+            TextField("", text: $inputNickName)
                 .textFieldStyle(.gimiBase)
             
             Spacer()
             
             Button(scene.buttonText) {
-                viewModel.send(.nickNameSave)
+                onComplete(inputNickName)
             }
             .buttonStyle(.gimiPrimary)
-            .disabled(viewModel.inputNickName.isEmpty)
+            .disabled(inputNickName.isEmpty)
         }
         .navigationBarBackButtonHidden()
         .padding()
@@ -63,6 +66,6 @@ enum NickNameInputScene {
 #Preview {
     let userViewModel = UserViewModel()
     
-    InputNickNameView(scene: .main)
+    InputNickNameView(scene: .main) { _ in }
         .environmentObject(userViewModel)
 }

--- a/GimiFeedback/GimiFeedback/Presentation/InputNickName/InputNickNameView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/InputNickName/InputNickNameView.swift
@@ -7,15 +7,16 @@
 
 import SwiftUI
 
-struct NickNameInputView: View {
+struct InputNickNameView: View {
     @EnvironmentObject var viewModel: UserViewModel
+    let scene: NickNameInputScene
     
     var body: some View {
         VStack(alignment: .leading) {
             Text("닉네임")
                 .font(.title1)
             
-            Text("피드백을 요청할 때 상대에게 보여질 닉네임이에요")
+            Text(scene.subTitle)
                 .font(.footnote)
                 .foregroundStyle(.gray400)
             
@@ -24,7 +25,7 @@ struct NickNameInputView: View {
             
             Spacer()
             
-            Button("시작하기") {
+            Button(scene.buttonText) {
                 viewModel.send(.nickNameSave)
             }
             .buttonStyle(.gimiPrimary)
@@ -36,9 +37,32 @@ struct NickNameInputView: View {
     }
 }
 
+enum NickNameInputScene {
+    case start
+    case main
+    
+    var subTitle: String {
+        switch self {
+        case .start:
+            "피드백을 요청할때 상대에게 보여질 닉네임이에요"
+        case .main:
+            "받는 사람에게 보일 닉네임이에요"
+        }
+    }
+    
+    var buttonText: String {
+        switch self {
+        case .start:
+            "시작하기"
+        case .main:
+            "다음"
+        }
+    }
+}
+
 #Preview {
     let userViewModel = UserViewModel()
     
-    NickNameInputView()
+    InputNickNameView(scene: .main)
         .environmentObject(userViewModel)
 }

--- a/GimiFeedback/GimiFeedback/Presentation/Start/NickNameInputView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Start/NickNameInputView.swift
@@ -30,7 +30,9 @@ struct NickNameInputView: View {
             .buttonStyle(.gimiPrimary)
             .disabled(viewModel.inputNickName.isEmpty)
         }
+        .navigationBarBackButtonHidden()
         .padding()
+        .padding(.top, 44)
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/Start/StartView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Start/StartView.swift
@@ -30,18 +30,18 @@ struct StartView: View {
                 }
                 .onChange(of: deepLinkViewModel.channel) { _, newValue in
                     if let channel = newValue {
-                        router.push(to: .feedbackWrite(channel: channel))
+                        router.push(to: .feedbackWriteInputNickName(channel: channel))
                         deepLinkViewModel.send(.resetChannel)
                     }
                 }
                 .onAppear {
                     if userViewModel.isLoggedIn {
-                        router.push(to: .inputNickName)
+                        router.push(to: .startUserinputNickName)
                     }
                 }
                 .onChange(of: userViewModel.isLoggedIn) { _, newValue in
                     if newValue {
-                        router.push(to: .inputNickName)
+                        router.push(to: .startUserinputNickName)
                     }
                 }
         }

--- a/GimiFeedback/GimiFeedback/Presentation/Start/StartView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Start/StartView.swift
@@ -36,12 +36,12 @@ struct StartView: View {
                 }
                 .onAppear {
                     if userViewModel.isLoggedIn {
-                        router.push(to: .nickNameInput)
+                        router.push(to: .inputNickName)
                     }
                 }
                 .onChange(of: userViewModel.isLoggedIn) { _, newValue in
                     if newValue {
-                        router.push(to: .nickNameInput)
+                        router.push(to: .inputNickName)
                     }
                 }
         }

--- a/GimiFeedback/GimiFeedback/Presentation/Start/StartView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Start/StartView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct StartView: View {
     @StateObject var router: OnboardingNavigationRouter
     @StateObject private var deepLinkViewModel: DeepLinkViewModel
+    @EnvironmentObject private var userViewModel: UserViewModel
     
     init() {
         _router = StateObject(wrappedValue: .init())
@@ -31,6 +32,16 @@ struct StartView: View {
                     if let channel = newValue {
                         router.push(to: .feedbackWrite(channel: channel))
                         deepLinkViewModel.send(.resetChannel)
+                    }
+                }
+                .onAppear {
+                    if userViewModel.isLoggedIn {
+                        router.push(to: .nickNameInput)
+                    }
+                }
+                .onChange(of: userViewModel.isLoggedIn) { _, newValue in
+                    if newValue {
+                        router.push(to: .nickNameInput)
                     }
                 }
         }

--- a/GimiFeedback/GimiFeedback/Presentation/Start/UserViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Start/UserViewModel.swift
@@ -11,12 +11,11 @@ final class UserViewModel: ViewModelable {
     enum Action {
         case kakaoLogin
         case kakaoLogout
-        case nickNameSave
+        case nickNameSave(String)
     }
     
     @Published private(set) var isLoggedIn: Bool = FirebaseAuthManager.currentUser
     @Published private(set) var saveUserNickName: String = FirebaseAuthManager.userNickName
-    @Published var inputNickName: String = ""
     
     func send(_ action: Action) {
         switch action {
@@ -39,7 +38,7 @@ final class UserViewModel: ViewModelable {
                 isLoggedIn = FirebaseAuthManager.currentUser
                 saveUserNickName = FirebaseAuthManager.userNickName
             }
-        case .nickNameSave:
+        case .nickNameSave(let inputNickName):
             Task {
                 await saveUser(nickName: inputNickName)
                 await nickNameChange(nickName: inputNickName)

--- a/GimiFeedback/GimiFeedback/Presentation/Start/UserViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Start/UserViewModel.swift
@@ -5,6 +5,7 @@
 //  Created by 김민석 on 7/12/25.
 //
 
+import Combine
 import Foundation
 
 final class UserViewModel: ViewModelable {
@@ -16,6 +17,25 @@ final class UserViewModel: ViewModelable {
     
     @Published private(set) var isLoggedIn: Bool = FirebaseAuthManager.currentUser
     @Published private(set) var saveUserNickName: String = FirebaseAuthManager.userNickName
+    @Published private(set) var userId: String = FirebaseAuthManager.currentUserID
+    
+    private var cancellable: AnyCancellable?
+    
+    init() {
+        observeFirebaseAuthState()
+    }
+
+    private func observeFirebaseAuthState() {
+        cancellable = NotificationCenter.default
+            .publisher(for: .firebaseAuthStateChanged)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                guard let self else { return }
+                self.isLoggedIn = FirebaseAuthManager.currentUser
+                self.saveUserNickName = FirebaseAuthManager.userNickName
+                self.userId = FirebaseAuthManager.currentUserID
+            }
+    }
     
     func send(_ action: Action) {
         switch action {
@@ -26,7 +46,6 @@ final class UserViewModel: ViewModelable {
                         email: result.email,
                         password: result.password
                     )
-                    isLoggedIn = FirebaseAuthManager.currentUser
                 }
             }
         case .kakaoLogout:
@@ -35,14 +54,11 @@ final class UserViewModel: ViewModelable {
                 if let logoutUserID = firebaseAuthLogout() {
                     await deleteUser(userID: logoutUserID)
                 }
-                isLoggedIn = FirebaseAuthManager.currentUser
-                saveUserNickName = FirebaseAuthManager.userNickName
             }
         case .nickNameSave(let inputNickName):
             Task {
                 await saveUser(nickName: inputNickName)
                 await nickNameChange(nickName: inputNickName)
-                saveUserNickName = inputNickName
             }
         }
     }
@@ -95,11 +111,11 @@ extension UserViewModel {
     /// 파이어베이스 로그아웃 로직
     private func firebaseAuthLogout() -> String? {
         do {
-            let userID = FirebaseAuthManager.currentUserID
+            let userId = userId
             try FirebaseAuthManager.shared.logout()
             print("파이어베이스 로그아웃 성공")
             
-            return userID
+            return userId
         } catch {
             print("파이어베이스 로그아웃 실패: \(error.localizedDescription)")
             
@@ -145,7 +161,6 @@ extension UserViewModel {
     private func nickNameChange(nickName: String) async {
         do {
             try await FirebaseAuthManager.shared.saveUserNickName(nickName: nickName)
-            saveUserNickName = nickName
         } catch {
             print("NickName 변경 실패", error.localizedDescription)
         }

--- a/GimiFeedback/GimiFeedback/Presentation/Start/UserViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Start/UserViewModel.swift
@@ -46,6 +46,8 @@ final class UserViewModel: ViewModelable {
                         email: result.email,
                         password: result.password
                     )
+                    
+                    await saveUser()
                 }
             }
         case .kakaoLogout:
@@ -57,8 +59,7 @@ final class UserViewModel: ViewModelable {
             }
         case .nickNameSave(let inputNickName):
             Task {
-                await saveUser(nickName: inputNickName)
-                await nickNameChange(nickName: inputNickName)
+                await saveUserNickName(to: inputNickName)
             }
         }
     }
@@ -126,13 +127,12 @@ extension UserViewModel {
     // MARK: 토큰 관련 함수
     
     /// 유저 저장 (로그인시)
-    private func saveUser(nickName: String) async {
+    private func saveUser() async {
         do {
             let tokenString = try await FCMManager.shared.getTokenString()
             let userID = FirebaseAuthManager.currentUserID
             let user = User(
                 userID: userID,
-                nickName: nickName,
                 fcmToken: tokenString,
                 badgeCount: 0
             )
@@ -158,7 +158,7 @@ extension UserViewModel {
         }
     }
     
-    private func nickNameChange(nickName: String) async {
+    private func saveUserNickName(to nickName: String) async {
         do {
             try await FirebaseAuthManager.shared.saveUserNickName(nickName: nickName)
         } catch {


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
### 닉네임 입력 화면을 구현했습니다.
- 로그인시 -> 닉네임 입력 없음
- 비로그인시 -> 닉네임 입력

### 닉네임입력 화면을 재사용했습니다.
- 로그인 후 닉네임 설정 -> 완료 처리(로그인 처리)
- 로그인 안하고 피드백 주기 -> 다음(피드백 작성하기)

### 닉네임 관련
1. 처음 로그인하고 닉네임을 입력해놓으면 추후 설정창이 생기지 않는 이상 닉네임 변경 X
처음 로그인 -> 닉네임 입력 -> 로그아웃 -> 다시 로그인 -> 닉네임 입력 없음
으로 진행됩니다.

자세한 내용은 스크린샷 짤을 확인해주세요

### 유저 데이터 관련
파이어베이스에 유저 데이터가 바뀌면 자동으로 NotificationCenter를 이용해서 해당 값들을 업데이트하도록 바꿨습니다

> 기존에는 로그인 완료시 ViewModel이 직접 바꿔줬습니다!

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

### 로그인 후 피드백 작성하는 화면
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-24 at 23 19 30](https://github.com/user-attachments/assets/f98365e0-c993-4200-9ac3-5480317ad5a5)

<br><br><hr><br><br>

### 로그인 안하고 피드백 작성하는 화면
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-24 at 23 19 52](https://github.com/user-attachments/assets/ab75cf44-29da-4ea2-a7d7-d8e88836b8e2)

<br><br><hr><br><br>

### 이미 회원가입 이력이 있는 아이디면 닉네임 받지 않는 화면
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-24 at 23 43 00](https://github.com/user-attachments/assets/d15273c7-7212-4f68-b1ac-ead41f7747dc)|

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
