### PR TITLE
피드백 공유 View에 토스트뷰 추가 (#134)

### DIFF
--- a/GimiFeedback/GimiFeedback/Presentation/ChannelCreateComplete/ChannelCreateCompleteView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelCreateComplete/ChannelCreateCompleteView.swift
@@ -51,6 +51,7 @@ struct ChannelCreateCompleteView: View {
                     Spacer()
                     
                     Button(action: {
+                        viewModel.showToast = true
                         UIPasteboard.general.string = channelID
                     }) {
                         Image(systemName: "document.on.document")
@@ -105,6 +106,12 @@ struct ChannelCreateCompleteView: View {
             .padding(.bottom, 40)
         }
         .navigationBarBackButtonHidden()
+        .overlay {
+            if viewModel.showToast {
+                ToastView(style: .basic(message: "코드가 복사되었습니다."), isPresented: $viewModel.showToast)
+                    .offset(y: 279)
+            }
+        }
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelCreateComplete/ChannelCreateCompleteView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelCreateComplete/ChannelCreateCompleteView.swift
@@ -51,7 +51,9 @@ struct ChannelCreateCompleteView: View {
                     Spacer()
                     
                     Button(action: {
-                        viewModel.showToast = true
+                        withAnimation {
+                            viewModel.showToast = true
+                        }
                         UIPasteboard.general.string = channelID
                     }) {
                         Image(systemName: "document.on.document")
@@ -94,7 +96,6 @@ struct ChannelCreateCompleteView: View {
                     }
                 }
             }
-            .padding(.horizontal, 20)
             
             Spacer()
             
@@ -102,14 +103,15 @@ struct ChannelCreateCompleteView: View {
                 router.popToRootView()
             }
             .buttonStyle(.gimiPrimary)
-            .padding(.horizontal, 20)
-            .padding(.bottom, 40)
+            .padding(.bottom, 37)
         }
+        .padding(.horizontal, 20)
         .navigationBarBackButtonHidden()
-        .overlay {
+        .overlay(alignment: .bottom) {
             if viewModel.showToast {
                 ToastView(style: .basic(message: "코드가 복사되었습니다."), isPresented: $viewModel.showToast)
-                    .offset(y: 279)
+                    .padding(.bottom, 81)
+                    .transition(.move(edge: .bottom))
             }
         }
     }

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelCreateComplete/ChannelCreateCompleteViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelCreateComplete/ChannelCreateCompleteViewModel.swift
@@ -12,6 +12,8 @@ final class ChannelCreateCompleteViewModel: ViewModelable {
         case shareToKakao(String)
     }
     
+    @Published var showToast: Bool = false
+    
     func send(_ action: Action) {
         switch action {
         case .shareToKakao(let channelID):


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
피드백 공유 뷰에서 코드 복사 버튼 누르면 토스트뷰 나오게 구현했습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
![Simulator Screen Recording - iPhone 16 Pro - 2025-07-28 at 17 11 07](https://github.com/user-attachments/assets/b0c5b3b9-2169-4651-9a61-3a70cb94b8f5)

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
113번째 줄에 padding이 81로 되어 있는데 이건 원래 값인 91로 하면 피그마에 있는 것보다 살짝 위로 올라가서 바꿨습니다.
스크린샷에 gif가 좀 끊깁니다
