### PR TITLE
피드백 디테일 카드가 어떤 상태인지 기능 추가 (#141)

### DIFF
--- a/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
+++ b/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		EC6A4CA12E34D5660087DB5C /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A4CA02E34D5660087DB5C /* ToastView.swift */; };
 		EC6A4CA32E34DBCC0087DB5C /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A4CA22E34DBCC0087DB5C /* UserDefaults+Extension.swift */; };
 		EC6A4CA52E350B720087DB5C /* Spicy+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A4CA42E350B720087DB5C /* Spicy+Extension.swift */; };
+		EC7CBBEA2E38DCC8008A9CF4 /* FeedbackCardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7CBBE92E38DCC8008A9CF4 /* FeedbackCardState.swift */; };
 		EC94C0F32E3746130020E59D /* GPTManger.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC94C0F22E3746130020E59D /* GPTManger.swift */; };
 		EC94C0F92E37AAAC0020E59D /* FeedbackDetail+CoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC94C0F82E37AAAC0020E59D /* FeedbackDetail+CoverView.swift */; };
 		EC94C0FB2E37AAC40020E59D /* FeedbackDetail+ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC94C0FA2E37AAC40020E59D /* FeedbackDetail+ContentView.swift */; };
@@ -117,6 +118,7 @@
 		EC6A4CA02E34D5660087DB5C /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		EC6A4CA22E34DBCC0087DB5C /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
 		EC6A4CA42E350B720087DB5C /* Spicy+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Spicy+Extension.swift"; sourceTree = "<group>"; };
+		EC7CBBE92E38DCC8008A9CF4 /* FeedbackCardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackCardState.swift; sourceTree = "<group>"; };
 		EC94C0F22E3746130020E59D /* GPTManger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTManger.swift; sourceTree = "<group>"; };
 		EC94C0F82E37AAAC0020E59D /* FeedbackDetail+CoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedbackDetail+CoverView.swift"; sourceTree = "<group>"; };
 		EC94C0FA2E37AAC40020E59D /* FeedbackDetail+ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedbackDetail+ContentView.swift"; sourceTree = "<group>"; };
@@ -465,6 +467,7 @@
 				EE856A482E1CD2D1006820B9 /* Feedback.swift */,
 				EE37553E2E1E10F5009AD262 /* FeedbackContent.swift */,
 				EE37553C2E1E10DF009AD262 /* FeedbackContentType.swift */,
+				EC7CBBE92E38DCC8008A9CF4 /* FeedbackCardState.swift */,
 				EEDBB1B92E28DA9100F16407 /* User.swift */,
 				EE856CA52E1D6D28006820B9 /* Navigation */,
 			);
@@ -731,6 +734,7 @@
 				EE465EEC2E262EDB0096109A /* MainNavigationRoutingView.swift in Sources */,
 				EE856A562E1CE604006820B9 /* ChannelListViewModel.swift in Sources */,
 				0DC2A3D52E263E1500FF91BC /* FeedbackDetailViewModel.swift in Sources */,
+				EC7CBBEA2E38DCC8008A9CF4 /* FeedbackCardState.swift in Sources */,
 				EC6A4C9B2E336DC80087DB5C /* FeedbackDetail+SectionView.swift in Sources */,
 				EE37582C2E1F80F3009AD262 /* Encodable+Extension.swift in Sources */,
 				EE856A542E1CE5B8006820B9 /* ViewModelable.swift in Sources */,

--- a/GimiFeedback/GimiFeedback/Model/FeedbackCardState.swift
+++ b/GimiFeedback/GimiFeedback/Model/FeedbackCardState.swift
@@ -1,0 +1,14 @@
+//
+//  FeedbackCardState.swift
+//  GimiFeedback
+//
+//  Created by 승찬 on 7/29/25.
+//
+
+import Foundation
+
+enum FeedbackCardState: Int, Codable {
+    case cover = 0
+    case trans
+    case original
+}

--- a/GimiFeedback/GimiFeedback/Model/FeedbackContent.swift
+++ b/GimiFeedback/GimiFeedback/Model/FeedbackContent.swift
@@ -14,6 +14,7 @@ struct FeedbackContent: Codable, Identifiable, Hashable {
     var visiable: Bool
     let type: FeedbackContentType
     var transContent: String?
+    var cardState: FeedbackCardState
     
     init(
         id: UUID = UUID(),
@@ -21,7 +22,8 @@ struct FeedbackContent: Codable, Identifiable, Hashable {
         spicy: Int,
         visiable: Bool = false,
         type: FeedbackContentType,
-        transContent: String? = nil
+        transContent: String? = nil,
+        cardState: FeedbackCardState = .cover
     ) {
         self.id = id
         self.content = content
@@ -29,6 +31,7 @@ struct FeedbackContent: Codable, Identifiable, Hashable {
         self.visiable = visiable
         self.type = type
         self.transContent = transContent
+        self.cardState = cardState
     }
 }
 

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailView.swift
@@ -23,13 +23,13 @@ struct FeedbackDetailView: View {
                     SectionView(
                         type: .typeContinue,
                         details: $viewModel.continueFeedbackList,
-                        onReveal: { _   in },
+                        onReveal: { viewModel.send(.updateCardState($0)) },
                         onTapTrans: { viewModel.send(.transContent($0))})
                     
                     SectionView(
                         type: .typeStop,
                         details: $viewModel.stopFeedbackList,
-                        onReveal: { _   in },
+                        onReveal: { viewModel.send(.updateCardState($0)) },
                         onTapTrans: { viewModel.send(.transContent($0))})
                 }
                 .padding(.top, 20)

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
@@ -40,6 +40,7 @@ final class FeedbackDetailViewModel: ViewModelable {
             updateVisibility(detail: detail)
         case .updateFeedbackVisibility:
             feedbackItem.visiable = true
+            updateFeedbackVisibility()
         case .updateToast:
             if UserDefaults.standard.isShowGuideToast == false {
                 isShowToast = true
@@ -129,4 +130,17 @@ extension FeedbackDetailViewModel {
             isLoading = false
         }
     }
+    
+    private func updateFeedbackVisibility() {
+           Task {
+               isLoading = true
+               do {
+                   try await FirestoreManager.shared.update(feedbackItem)
+               } catch {
+                   errorMessage = "원문 표시 실패: \(error.localizedDescription)"
+                   print("원문 표시 실패: \(error.localizedDescription)")
+               }
+               isLoading = false
+           }
+       }
 }

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
@@ -15,6 +15,7 @@ final class FeedbackDetailViewModel: ViewModelable {
         case updateFeedbackVisibility
         case updateToast
         case transContent(FeedbackContent)
+        case updateCardState(FeedbackContent)
     }
     
     var feedbackItem: Feedback
@@ -46,6 +47,8 @@ final class FeedbackDetailViewModel: ViewModelable {
             }
         case .transContent(let content):
             transFeedbackContent(content: content)
+        case .updateCardState(let detail):
+            updateCardState(detail: detail)
         }
     }
 }
@@ -97,6 +100,26 @@ extension FeedbackDetailViewModel {
             
             continueFeedbackList = feedbackItem.content.filter { $0.type == .typeContinue }
             stopFeedbackList = feedbackItem.content.filter { $0.type == .typeStop }
+            do {
+                try await FirestoreManager.shared.update(feedbackItem)
+            } catch {
+                errorMessage = "원문 표시 실패: \(error.localizedDescription)"
+                print("원문 표시 실패: \(error.localizedDescription)")
+            }
+            isLoading = false
+        }
+    }
+    
+    private func updateCardState(detail: FeedbackContent) {
+        guard let index = feedbackItem.content.firstIndex(where: { $0.id == detail.id }) else { return }
+        
+        feedbackItem.content[index].cardState = detail.cardState
+        
+        continueFeedbackList = feedbackItem.content.filter { $0.type == .typeContinue }
+        stopFeedbackList = feedbackItem.content.filter { $0.type == .typeStop }
+        
+        Task {
+            isLoading = true
             do {
                 try await FirestoreManager.shared.update(feedbackItem)
             } catch {

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/SubView/FeedbackDetail+FeedbackRowView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/SubView/FeedbackDetail+FeedbackRowView.swift
@@ -7,23 +7,15 @@
 
 import SwiftUI
 
-enum FeedbackCardState {
-    case cover
-    case trans
-    case original
-}
-
 extension FeedbackDetailView {
     struct FeedbackRowView: View {
         @Binding var detail: FeedbackContent
         let onReveal: (FeedbackContent) -> Void
         let onTapTrans: () -> Void // transContent 값이 있으면 그냥 토글, 없으면 gpt로 변환
-
-        @State private var cardState: FeedbackCardState = .cover
-
+        
         var body: some View {
             ZStack {
-                switch cardState {
+                switch detail.cardState {
                 case .cover:
                     CoverView(
                         detail: detail,
@@ -32,9 +24,13 @@ extension FeedbackDetailView {
                             if detail.transContent == nil {
                                 onTapTrans()
                             }
-                            cardState = .trans
+                            detail.cardState = .trans
+                            onReveal(detail)
                         },
-                        onTapOriginalContent: { cardState = .original }
+                        onTapOriginalContent: {
+                            detail.cardState = .original
+                            onReveal(detail)
+                        }
                     )
 
                 case .trans:
@@ -43,8 +39,14 @@ extension FeedbackDetailView {
                         contentType: .trans,
                         contentText: detail.transContent,
                         buttonText: "원문 보기",
-                        onTapToggle: { cardState = .original },
-                        onTapContent: { cardState = .cover }
+                        onTapToggle: {
+                            detail.cardState = .original
+                            onReveal(detail)
+                        },
+                        onTapContent: {
+                            detail.cardState = .cover
+                            onReveal(detail)
+                        }
                     )
 
                 case .original:
@@ -57,9 +59,13 @@ extension FeedbackDetailView {
                             if detail.transContent == nil {
                                 onTapTrans()
                             }
-                            cardState = .trans
+                            detail.cardState = .trans
+                            onReveal(detail)
                         },
-                        onTapContent: { cardState = .cover }
+                        onTapContent: {
+                            detail.cardState = .cover
+                            onReveal(detail)
+                        }
                     )
                 }
             }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
피드백 디테일 뷰의 피드백 카드의 마지막 상태를 업데이트 했습니다.


## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

|이전 상태 (돌아가면 다 리셋이됌)|현재 상태 (마지막 상태유지)|
|---|---|
|![전](https://github.com/user-attachments/assets/17207b54-d94f-4690-8dd9-bbbbb9d0b04b)|![후](https://github.com/user-attachments/assets/530ed375-b8ee-4e24-954e-c9730bdcd3c0)|



## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
