### PR TITLE
공유하기 관련 결정된 부분 추가 및 채널 수정뷰 Hi-Fi 수정 (#146)

### DIFF
--- a/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
+++ b/GimiFeedback/GimiFeedback.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		EC6A4CA32E34DBCC0087DB5C /* UserDefaults+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A4CA22E34DBCC0087DB5C /* UserDefaults+Extension.swift */; };
 		EC6A4CA52E350B720087DB5C /* Spicy+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A4CA42E350B720087DB5C /* Spicy+Extension.swift */; };
 		EC7CBBEA2E38DCC8008A9CF4 /* FeedbackCardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7CBBE92E38DCC8008A9CF4 /* FeedbackCardState.swift */; };
+		EC7CBBEC2E3914FE008A9CF4 /* ChannelDetail+ShareButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7CBBEB2E3914FE008A9CF4 /* ChannelDetail+ShareButtonView.swift */; };
+		EC7CBBEE2E391551008A9CF4 /* ChannelDetail+ShareSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7CBBED2E391551008A9CF4 /* ChannelDetail+ShareSheetView.swift */; };
 		EC94C0F32E3746130020E59D /* GPTManger.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC94C0F22E3746130020E59D /* GPTManger.swift */; };
 		EC94C0F92E37AAAC0020E59D /* FeedbackDetail+CoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC94C0F82E37AAAC0020E59D /* FeedbackDetail+CoverView.swift */; };
 		EC94C0FB2E37AAC40020E59D /* FeedbackDetail+ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC94C0FA2E37AAC40020E59D /* FeedbackDetail+ContentView.swift */; };
@@ -135,6 +137,8 @@
 		EC6A4CA22E34DBCC0087DB5C /* UserDefaults+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+Extension.swift"; sourceTree = "<group>"; };
 		EC6A4CA42E350B720087DB5C /* Spicy+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Spicy+Extension.swift"; sourceTree = "<group>"; };
 		EC7CBBE92E38DCC8008A9CF4 /* FeedbackCardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackCardState.swift; sourceTree = "<group>"; };
+		EC7CBBEB2E3914FE008A9CF4 /* ChannelDetail+ShareButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelDetail+ShareButtonView.swift"; sourceTree = "<group>"; };
+		EC7CBBED2E391551008A9CF4 /* ChannelDetail+ShareSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChannelDetail+ShareSheetView.swift"; sourceTree = "<group>"; };
 		EC94C0F22E3746130020E59D /* GPTManger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GPTManger.swift; sourceTree = "<group>"; };
 		EC94C0F82E37AAAC0020E59D /* FeedbackDetail+CoverView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedbackDetail+CoverView.swift"; sourceTree = "<group>"; };
 		EC94C0FA2E37AAC40020E59D /* FeedbackDetail+ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedbackDetail+ContentView.swift"; sourceTree = "<group>"; };
@@ -282,6 +286,8 @@
 				EC6A4C852E3129300087DB5C /* ChannelDetail+EmptyFeedbackView.swift */,
 				EC6A4C872E312A3B0087DB5C /* ChannelDetail+FeedbackListView.swift */,
 				EC6A4C892E312D410087DB5C /* ChannelDetail+FeedbackRowView.swift */,
+				EC7CBBEB2E3914FE008A9CF4 /* ChannelDetail+ShareButtonView.swift */,
+				EC7CBBED2E391551008A9CF4 /* ChannelDetail+ShareSheetView.swift */,
 			);
 			path = SubViews;
 			sourceTree = "<group>";
@@ -763,6 +769,7 @@
 				EE465EF82E2632B20096109A /* ChannelCreateCompleteView.swift in Sources */,
 				EC6A4C8D2E3227120087DB5C /* ChannelEdit+TitleView.swift in Sources */,
 				EE465F022E26510A0096109A /* ChannelList+ListItemView.swift in Sources */,
+				EC7CBBEE2E391551008A9CF4 /* ChannelDetail+ShareSheetView.swift in Sources */,
 				EC9959BA2E25145B001555B1 /* FeedbackDetailView.swift in Sources */,
 				EE3756A32E1E602F009AD262 /* EntityRepresentable.swift in Sources */,
 				EEC048752E2E916100918BAA /* SpeechView.swift in Sources */,
@@ -817,6 +824,7 @@
 				EEDBB1BC2E28DEC100F16407 /* FCMManager.swift in Sources */,
 				EC6A4C862E3129300087DB5C /* ChannelDetail+EmptyFeedbackView.swift in Sources */,
 				EE856A442E1CD244006820B9 /* Color+Extension.swift in Sources */,
+				EC7CBBEC2E3914FE008A9CF4 /* ChannelDetail+ShareButtonView.swift in Sources */,
 				D306028D2E377EC500908D1D /* FeedbackWriteView.swift in Sources */,
 				D306028E2E377EC500908D1D /* FeedbackWriteViewModel.swift in Sources */,
 				EE465F062E27B2420096109A /* InputCodeViewModel.swift in Sources */,

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/ChannelDetailView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/ChannelDetailView.swift
@@ -5,6 +5,9 @@ struct ChannelDetailView: View {
     @StateObject var viewModel: ChannelDetailViewModel
     @EnvironmentObject var router: MainNavigationRouter
     @State private var isShowDeleteAlert: Bool = false
+    @State private var isShowSheet: Bool = false
+    @State private var isShowActivity: Bool = false
+    @State private var isShowToast: Bool = false
     
     init(channelItem: FeedbackChannel) {
         _viewModel = StateObject(wrappedValue: .init(channelItem: channelItem))
@@ -25,7 +28,7 @@ struct ChannelDetailView: View {
                 
                 /// 피드백 없을 때 화면
                 if viewModel.feedbackList.isEmpty {
-                    EmptyFeedbackView(channelId: viewModel.channelItem.id)
+                    EmptyFeedbackView(channelId: viewModel.channelItem.id, tapAction: { isShowSheet = true })
                 } else {
                     /// 피드백 있을 때 화면
                     FeedbackListView(
@@ -40,10 +43,11 @@ struct ChannelDetailView: View {
         .gimiNavigationBar(
             title: "\(viewModel.channelItem.channelTitle)",
             trailingItems: {
-                ShareLink(item: "gimifeedback://feedbackWrite/\(viewModel.channelItem.id)") {
+                Button(action: { isShowSheet = true }) {
                     Image(systemName: "square.and.arrow.up")
                         .foregroundStyle(.black)
                 }
+                
                 Button(action: { isShowDeleteAlert = true }) {
                     Image(systemName: "trash")
                         .foregroundStyle(.black)
@@ -51,7 +55,6 @@ struct ChannelDetailView: View {
             }
         )
         .alert("채널 삭제하기", isPresented: $isShowDeleteAlert) {
-            
             Button(action: {
                 isShowDeleteAlert = true
             }) {
@@ -67,6 +70,16 @@ struct ChannelDetailView: View {
             }
         } message: {
             Text("정말 삭제하시겠습니까?\n이 작업은 되돌릴 수 없습니다.")
+        }
+        .sheet(isPresented: $isShowSheet) {
+            ShareSheetView(
+                isSheet: $isShowSheet,
+                isShowToast: $isShowToast,
+                isShowActivity: $isShowActivity,
+                channelId: viewModel.channelItem.id.uuidString,
+                shareToKakaoAction: {
+                    viewModel.send(.shareToKakao(viewModel.channelItem.id.uuidString))
+                })
         }
         .onChange(of: viewModel.isDelete) { _, new in
             if new == true {

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/SubViews/ChannelDetail+EmptyFeedbackView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/SubViews/ChannelDetail+EmptyFeedbackView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 extension ChannelDetailView {
     struct EmptyFeedbackView: View {
         let channelId: UUID
+        let tapAction: () -> Void
 
         var body: some View {
             VStack(alignment: .center, spacing: 20) {
@@ -22,17 +23,7 @@ extension ChannelDetailView {
                     .foregroundStyle(.primaryDarken100)
                     .multilineTextAlignment(.center)
                 
-                // TODO: 공유하기를 누를때 어떻게 할건지 (카카오톡과 일반 ShareLink 방법 중 논의)
-//                Button(action: { }) {
-//                    Text("채널 공유하기")
-//                        .font(.callout2)
-//                        .foregroundStyle(.primaryDarken100)
-//                        .frame(width: 123, height: 47)
-//                        .background(.primaryLighten300)
-//                        .clipShape(.rect(cornerRadius: 12))
-//                }
-//                
-                ShareLink(item: "gimifeedback://feedbackWrite/\(channelId)") {
+                Button(action: { tapAction() }) {
                     Text("채널 공유하기")
                         .font(.callout2)
                         .foregroundStyle(.primaryDarken100)

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/SubViews/ChannelDetail+ShareButtonView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/SubViews/ChannelDetail+ShareButtonView.swift
@@ -1,0 +1,80 @@
+//
+//  ChannelDetail+ShareButtonView.swift
+//  GimiFeedback
+//
+//  Created by 승찬 on 7/29/25.
+//
+
+import SwiftUI
+
+enum ShareType {
+    case system(String)
+    case asset(String)
+}
+
+extension ChannelDetailView {
+    struct ShareButtonView: View {
+        let icon: ShareType
+        let text: String
+        let onTapAction: () -> Void
+
+        var body: some View {
+            Group {
+                switch icon {
+                case .system(let imageName):
+                    HStack(spacing: 16) {
+                        Circle()
+                            .fill(Color.primaryLighten300)
+                            .frame(width: 44, height: 44)
+                            .overlay(alignment: .center) {
+                                Image(systemName: imageName)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 23, height: 24)
+                                    .padding(7)
+                                    .foregroundStyle(.brandGreen300)
+                            }
+                        
+                        Text(text)
+                            .font(.callout)
+                            .foregroundStyle(.gray900)
+                        
+                        Spacer()
+                    }
+                    .padding(.vertical, 10)
+                    .frame(height: 64)
+                    .background(.white)
+                    .onTapGesture {
+                        onTapAction()
+                    }
+                    
+                case .asset(let imageName):
+                    HStack(spacing: 16) {
+                        Circle()
+                            .fill(Color.primaryLighten300)
+                            .frame(width: 44, height: 44)
+                            .overlay(alignment: .center) {
+                                Image(imageName)
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 32, height: 30)
+                                    .padding(6)
+                            }
+
+                        Text(text)
+                            .font(.callout)
+                            .foregroundStyle(.gray900)
+                        
+                        Spacer()
+                    }
+                    .padding(.vertical, 10)
+                    .frame(height: 64)
+                    .background(.white)
+                    .onTapGesture {
+                        onTapAction()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/SubViews/ChannelDetail+ShareSheetView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/SubViews/ChannelDetail+ShareSheetView.swift
@@ -1,0 +1,92 @@
+//
+//  ChannelDetail+ShareSheetView.swift
+//  GimiFeedback
+//
+//  Created by 승찬 on 7/29/25.
+//
+
+import SwiftUI
+
+extension ChannelDetailView {
+    struct ShareSheetView: View {
+        @Binding var isSheet: Bool
+        @Binding var isShowToast: Bool
+        @Binding var isShowActivity: Bool
+        let channelId: String
+        let shareToKakaoAction: () -> Void
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: .zero) {
+                HStack {
+                    Text("채널 공유하기")
+                        .font(.headline)
+
+                    Spacer()
+
+                    Button(action: { isSheet = false }) {
+                        Image(systemName: "xmark")
+                            .resizable()
+                            .frame(width: 20, height: 20)
+                            .padding(12)
+                    }
+                }
+                .foregroundStyle(.black)
+                .padding(.top, 24)
+                .padding(.bottom, 18)
+
+                VStack(alignment: .leading, spacing: .zero) {
+                    ShareButtonView(
+                        icon: .asset("KakaoIcon"),
+                        text: "카카오톡 초대장 보내기",
+                        onTapAction: {
+                            shareToKakaoAction()
+                        })
+
+                    ShareButtonView(
+                        icon: .system("document.on.document"),
+                        text: "코드 복사",
+                        onTapAction: {
+                            withAnimation {
+                                UIPasteboard.general.string = channelId
+                                isShowToast = true
+                            }
+                        })
+
+                    ShareButtonView(
+                        icon: .system("square.and.arrow.up"),
+                        text: "외부 공유",
+                        onTapAction: {
+                            isShowActivity = true
+                        })
+                    .sheet(isPresented: $isShowActivity) {
+                        ActivityView(items: ["gimifeedback://feedbackWrite/\(channelId)"])
+                            .presentationDetents([.medium, .large])
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .overlay(alignment: .bottom) {
+                    if isShowToast {
+                        ToastView(style: .basic(message: "코드가 복사되었어요."), isPresented: $isShowToast)
+                            .padding(.bottom, 53)
+                            .transition(.move(edge: .bottom))
+                    }
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .presentationDetents([.height(300)])
+            .presentationCornerRadius(30)
+        }
+    }
+}
+
+struct ActivityView: UIViewControllerRepresentable {
+    let items: [Any]
+    
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+    
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) { }
+}

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelEdit/SubViews/ChannelEdit+TitleView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelEdit/SubViews/ChannelEdit+TitleView.swift
@@ -25,6 +25,7 @@ extension ChannelEditView {
                 
                 TextField("", text: $text)
                     .textFieldStyle(.gimiTitle)
+                    .textFieldLimit(text: $text, maximumText: 15)
                     .padding(.top, 10)
                     .focused(focusState, equals: field)
             }

--- a/GimiFeedback/GimiFeedback/Presentation/Components/GimiTextEditorModifier.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Components/GimiTextEditorModifier.swift
@@ -62,7 +62,7 @@ struct TextEditorLimitModifier: ViewModifier {
         content
             .overlay(alignment: .bottomTrailing) {
                 Text("(\(text.count) / \(maximumText))")
-                    .font(.system(size: 12))
+                    .font(.caption1)
                     .foregroundColor(.gray700)
                     .padding()
             }

--- a/GimiFeedback/GimiFeedback/Presentation/Components/GimiTextFieldStyle.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Components/GimiTextFieldStyle.swift
@@ -51,10 +51,38 @@ extension TextFieldStyle where Self == GimiTextFieldStyle {
     }
 }
 
+/// 텍스트 필드 글자수 제한
+struct TextFieldLimitModifier: ViewModifier {
+    @Binding var text: String
+    let maximumText: Int
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay(alignment: .trailing) {
+                Text("(\(text.count) / \(maximumText))")
+                    .font(.caption1)
+                    .foregroundColor(.gray700)
+                    .padding()
+            }
+            .onChange(of: text) { _, newValue in
+                if newValue.count > maximumText {
+                    text = String(newValue.prefix(maximumText))
+                }
+            }
+    }
+}
+
+extension View {
+    func textFieldLimit(text: Binding<String>, maximumText: Int) -> some View {
+        self.modifier(TextFieldLimitModifier(text: text, maximumText: maximumText))
+    }
+}
+
 #Preview {
     struct PreviewContainer: View {
         @State private var texts = ["", "test"]
         private let placeHolder = "PlaceHolder"
+        @State private var test = "12412421421421"
         
         var body: some View {
             VStack(spacing: 16) {
@@ -62,8 +90,9 @@ extension TextFieldStyle where Self == GimiTextFieldStyle {
                     TextField("test용 입니다.", text: $texts[index])
                         .textFieldStyle(.gimiBase)
                 }
-                TextField("제목 입력", text: .constant(""))
+                TextField("제목 입력", text: $test)
                     .textFieldStyle(.gimiTitle)
+                    .textFieldLimit(text: $test, maximumText: 15)
             }
             .padding()
             .background(.white)

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailView.swift
@@ -63,7 +63,6 @@ struct FeedbackDetailView: View {
         }
         .onAppear {
             viewModel.send(.updateFeedbackVisibility)
-            viewModel.send(.updateToast)
         }
     }
 }

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
@@ -13,7 +13,6 @@ final class FeedbackDetailViewModel: ViewModelable {
         case deleteFeedback
         case visualizeDetail(detail: FeedbackContent)
         case updateFeedbackVisibility
-        case updateToast
         case transContent(FeedbackContent)
         case updateCardState(FeedbackContent)
     }
@@ -41,11 +40,6 @@ final class FeedbackDetailViewModel: ViewModelable {
         case .updateFeedbackVisibility:
             feedbackItem.visiable = true
             updateFeedbackVisibility()
-        case .updateToast:
-            if UserDefaults.standard.isShowGuideToast == false {
-                isShowToast = true
-                UserDefaults.standard.saveGuideToast()
-            }
         case .transContent(let content):
             transFeedbackContent(content: content)
         case .updateCardState(let detail):

--- a/GimiFeedback/GimiFeedback/Presentation/Start/UserViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/Start/UserViewModel.swift
@@ -55,7 +55,6 @@ final class UserViewModel: ViewModelable {
                 await kakaoLogout()
                 if let logoutUserID = firebaseAuthLogout() {
                     await deleteUser(userID: logoutUserID)
-                    UserDefaults.standard.removeGuideToast()
                 }
             }
         case .nickNameSave(let inputNickName):

--- a/GimiFeedback/GimiFeedback/Util/Extension/UserDefaults+Extension.swift
+++ b/GimiFeedback/GimiFeedback/Util/Extension/UserDefaults+Extension.swift
@@ -8,20 +8,5 @@
 import Foundation
 
 extension UserDefaults {
-    private enum Key {
-        static let guideToast = "guideToast"
-    }
     
-    func saveGuideToast() {
-        set(true, forKey: Key.guideToast)
-    }
-
-    /// 토스트를 보여준 적이 있는지 확인
-    var isShowGuideToast: Bool {
-        bool(forKey: Key.guideToast)
-    }
-    
-    func removeGuideToast() {
-        removeObject(forKey: Key.guideToast)
-    }
 }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
공유하기 관련 결정된 부분 추가 및 채널 수정뷰 Hi-Fi 수정했습니다.
- [x] 채널 디테일 페이지에서 채널 공유하기 관련 로직 추가
- [x] Hi-Fi 수정에 따른 ChannelEdit 뷰 수정 
- [x] 롱프르레스 애니메이션 사라짐에 따라 가이드 토스트 로직 제거

## 📸 Screenshot
|공유하기 시트|수정전 채널 수정뷰|수정후 채널 수정뷰 (글자수 제한 추가)|
|---|---|---|
|![Simulator Screen Recording - iPhone 16 - 2025-07-30 at 00 00 14](https://github.com/user-attachments/assets/b7093e2a-37fe-4249-8b71-070e70dc04b7)|<img width="300" alt="Simulator Screenshot - iPhone 16 - 2025-07-29 at 23 59 14" src="https://github.com/user-attachments/assets/6c2ec9c0-b5c1-4e64-872e-4decf2040069" />|<img width="300" alt="Simulator Screenshot - iPhone 16 - 2025-07-29 at 23 59 38" src="https://github.com/user-attachments/assets/46965806-89b6-4433-9dfc-50157827b794" />|


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
