### PR TITLE
Hi-Fi Flow2 부분 전체적인 로딩 뷰 추가 (#154)

### DIFF
--- a/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/ChannelDetailView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/ChannelDetailView.swift
@@ -15,27 +15,27 @@ struct ChannelDetailView: View {
     
     var body: some View {
         ZStack {
-            switch viewModel.isLoading {
-            case true:
-                LoadingView(text: "로딩 중 입니다.")
-            case false:
-                ScrollView {
-                    VStack(spacing: .zero) {
-                        /// 콘텐츠 설명
-                        DescriptionView(
-                            channelItem: viewModel.channelItem,
-                            onTapEdit: {
-                                router.push(
-                                    to: .channelEdit(channelItem: viewModel.channelItem)
-                                )
-                            }
-                        )
-                        
-                        /// 피드백 없을 때 화면
-                        if viewModel.feedbackList.isEmpty {
-                            EmptyFeedbackView(channelId: viewModel.channelItem.id, tapAction: { isShowSheet = true })
-                        } else {
-                            /// 피드백 있을 때 화면
+            ScrollView {
+                VStack(spacing: .zero) {
+                    /// 콘텐츠 설명 (항상 노출)
+                    DescriptionView(
+                        channelItem: viewModel.channelItem,
+                        onTapEdit: {
+                            router.push(
+                                to: .channelEdit(channelItem: viewModel.channelItem)
+                            )
+                        }
+                    )
+                    
+                    /// 피드백 영역만 로딩 분기
+                    if !viewModel.isLoading {
+                        switch viewModel.feedbackList.isEmpty {
+                        case true:
+                            EmptyFeedbackView(
+                                channelId: viewModel.channelItem.id,
+                                tapAction: { isShowSheet = true }
+                            )
+                        case false:
                             FeedbackListView(
                                 feedbackList: viewModel.feedbackList,
                                 onTapFeedbackItem: { item in
@@ -45,6 +45,11 @@ struct ChannelDetailView: View {
                         }
                     }
                 }
+            }
+        }
+        .overlay(alignment: .center) {
+            if viewModel.isLoading {
+                LoadingView(text: "로딩 중 입니다.")
             }
         }
         .gimiNavigationBar(

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/ChannelDetailView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/ChannelDetailView.swift
@@ -14,29 +14,36 @@ struct ChannelDetailView: View {
     }
     
     var body: some View {
-        ScrollView {
-            VStack(spacing: .zero) {
-                /// 콘텐츠 설명
-                DescriptionView(
-                    channelItem: viewModel.channelItem,
-                    onTapEdit: {
-                        router.push(
-                            to: .channelEdit(channelItem: viewModel.channelItem)
+        ZStack {
+            switch viewModel.isLoading {
+            case true:
+                LoadingView(text: "로딩 중 입니다.")
+            case false:
+                ScrollView {
+                    VStack(spacing: .zero) {
+                        /// 콘텐츠 설명
+                        DescriptionView(
+                            channelItem: viewModel.channelItem,
+                            onTapEdit: {
+                                router.push(
+                                    to: .channelEdit(channelItem: viewModel.channelItem)
+                                )
+                            }
                         )
-                    }
-                )
-                
-                /// 피드백 없을 때 화면
-                if viewModel.feedbackList.isEmpty {
-                    EmptyFeedbackView(channelId: viewModel.channelItem.id, tapAction: { isShowSheet = true })
-                } else {
-                    /// 피드백 있을 때 화면
-                    FeedbackListView(
-                        feedbackList: viewModel.feedbackList,
-                        onTapFeedbackItem: { item in
-                            router.push(to: .feedbackDetail(feedback: item))
+                        
+                        /// 피드백 없을 때 화면
+                        if viewModel.feedbackList.isEmpty {
+                            EmptyFeedbackView(channelId: viewModel.channelItem.id, tapAction: { isShowSheet = true })
+                        } else {
+                            /// 피드백 있을 때 화면
+                            FeedbackListView(
+                                feedbackList: viewModel.feedbackList,
+                                onTapFeedbackItem: { item in
+                                    router.push(to: .feedbackDetail(feedback: item))
+                                }
+                            )
                         }
-                    )
+                    }
                 }
             }
         }
@@ -91,6 +98,7 @@ struct ChannelDetailView: View {
         }
         .refreshable {
             viewModel.send(.getFeedbackChannelItem)
+            viewModel.send(.fetchFeedbackList)
         }
     }
 }

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/ChannelDetailViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelDetail/ChannelDetailViewModel.swift
@@ -14,9 +14,17 @@ final class ChannelDetailViewModel: ViewModelable {
     
     @Published private(set) var feedbackList: [Feedback] = []
     @Published private(set) var errorMessage: String?
-    @Published private(set) var isLoading: Bool = false
+    @Published private(set) var isChannelItem: Bool = false
+    @Published private(set) var isFeedbackListLoading: Bool = false
+    @Published private(set) var isDeleteChannelLoading: Bool = false
     
     @Published var isDelete = false
+
+    var isLoading: Bool {
+        isChannelItem
+        || isFeedbackListLoading
+        || isDeleteChannelLoading
+    }
     
     init(channelItem: FeedbackChannel) {
         self.channelItem = channelItem
@@ -46,7 +54,7 @@ final class ChannelDetailViewModel: ViewModelable {
 extension ChannelDetailViewModel {
     private func getFeedbackChannelItem() {
         Task {
-            isLoading = true
+            isChannelItem = true
             do {
                 guard let update: FeedbackChannel = try await FirestoreManager.shared.get(
                     channelItem.id.uuidString,
@@ -57,13 +65,13 @@ extension ChannelDetailViewModel {
             } catch {
                 errorMessage = error.localizedDescription
             }
-            isLoading = true
+            isChannelItem = false
         }
     }
     
     private func fetchFeedbackList(channelID: UUID) {
         Task {
-            isLoading = true
+            isFeedbackListLoading = true
             do {
                 feedbackList = try await FirestoreManager.shared.fetch(
                     as: Feedback.self, .feedback,
@@ -73,13 +81,13 @@ extension ChannelDetailViewModel {
                 errorMessage = error.localizedDescription
             }
             
-            isLoading = false
+            isFeedbackListLoading = false
         }
     }
     
     private func deleteChannel(channelItem: FeedbackChannel) {
         Task {
-            isLoading = true
+            isDeleteChannelLoading = true
             do {
                 for feedback in feedbackList {
                     try await FirestoreManager.shared.delete(feedback)
@@ -90,7 +98,7 @@ extension ChannelDetailViewModel {
             } catch {
                 errorMessage = error.localizedDescription
             }
-            isLoading = false
+            isDeleteChannelLoading = false
         }
     }
 }

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelEdit/ChannelEditView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelEdit/ChannelEditView.swift
@@ -24,30 +24,38 @@ struct ChannelEditView: View {
     }
     
     var body: some View {
-        VStack(spacing: .zero) {
-            TitleView(
-                text: $viewModel.channelItem.channelTitle,
-                field: .title,
-                focusState: $focusField
-            )
-            
-            ContentView(
-                text: $viewModel.channelItem.content,
-                field: .content,
-                focusState: $focusField)
-            
-            Spacer()
-            
-            Button("저장하기") {
-                isShowCreateAlert = true
+        ZStack {
+            switch viewModel.isLoading {
+            case true:
+                LoadingView(text: "로딩 중 입니다.")
+            case false:
+                VStack(spacing: .zero) {
+                    TitleView(
+                        text: $viewModel.channelItem.channelTitle,
+                        field: .title,
+                        focusState: $focusField
+                    )
+                    
+                    ContentView(
+                        text: $viewModel.channelItem.content,
+                        field: .content,
+                        focusState: $focusField)
+                    
+                    Spacer()
+                    
+                    Button("저장하기") {
+                        isShowCreateAlert = true
+                    }
+                    .buttonStyle(.gimiPrimary)
+                    .disabled(!viewModel.isActive)
+                }
+                .padding(.horizontal, 20)
+                .background(.white)
+                .onTapGesture {
+                    focusField = nil
+                }
             }
-            .buttonStyle(.gimiPrimary)
-            .disabled(!viewModel.isActive)
-        }
-        .padding(.horizontal, 20)
-        .background(.white)
-        .onTapGesture {
-            focusField = nil
+            
         }
         .gimiNavigationBar(title: "채널 수정하기")
         .navigationBarTitleDisplayMode(.inline)

--- a/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/ChannelList/ChannelListView.swift
@@ -20,7 +20,11 @@ struct ChannelListView: View {
             VStack(spacing: 0) {
                 HeaderView()
                 
-                ChannelGridView(viewModel: viewModel)
+                if !viewModel.isChannelListLoading {
+                    ChannelGridView(viewModel: viewModel)
+                }
+                
+                Spacer()
             }
 
             if viewModel.isChannelListLoading {

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailView.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailView.swift
@@ -10,34 +10,43 @@ struct FeedbackDetailView: View {
     }
     
     var body: some View {
-        ScrollView {
-            /// 전체
-            VStack(alignment: .leading, spacing: .zero) {
-                DescriptionView(
-                    writePerson: viewModel.feedbackItem.writePerson,
-                    date: viewModel.feedbackItem.date.formattedDate
-                )
-                
-                /// 피드백 리스트
-                VStack(spacing: 40) {
-                    SectionView(
-                        type: .typeContinue,
-                        details: $viewModel.continueFeedbackList,
-                        onReveal: { viewModel.send(.updateCardState($0)) },
-                        onTapTrans: { viewModel.send(.transContent($0))})
+        ZStack {
+            ScrollView {
+                /// 전체
+                VStack(alignment: .leading, spacing: .zero) {
+                    DescriptionView(
+                        writePerson: viewModel.feedbackItem.writePerson,
+                        date: viewModel.feedbackItem.date.formattedDate
+                    )
                     
-                    SectionView(
-                        type: .typeStop,
-                        details: $viewModel.stopFeedbackList,
-                        onReveal: { viewModel.send(.updateCardState($0)) },
-                        onTapTrans: { viewModel.send(.transContent($0))})
+                    if !viewModel.isLoading {
+                        /// 피드백 리스트
+                        VStack(spacing: 40) {
+                            SectionView(
+                                type: .typeContinue,
+                                details: $viewModel.continueFeedbackList,
+                                onReveal: { viewModel.send(.updateCardState($0)) },
+                                onTapTrans: { viewModel.send(.transContent($0))})
+                            
+                            SectionView(
+                                type: .typeStop,
+                                details: $viewModel.stopFeedbackList,
+                                onReveal: { viewModel.send(.updateCardState($0)) },
+                                onTapTrans: { viewModel.send(.transContent($0))})
+                        }
+                        .padding(.top, 20)
+                    }
                 }
-                .padding(.top, 20)
+            }
+            .overlay(alignment: .center) {
+                if viewModel.isShowToast {
+                    ToastView(style: .guide, isPresented: $viewModel.isShowToast)
+                }
             }
         }
         .overlay(alignment: .center) {
-            if viewModel.isShowToast {
-                ToastView(style: .guide, isPresented: $viewModel.isShowToast)
+            if viewModel.isLoading {
+                LoadingView(text: "로딩 중 입니다.")
             }
         }
         .gimiNavigationBar(

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
@@ -11,7 +11,6 @@ final class FeedbackDetailViewModel: ViewModelable {
     
     enum Action {
         case deleteFeedback
-        case visualizeDetail(detail: FeedbackContent)
         case updateFeedbackVisibility
         case transContent(FeedbackContent)
         case updateCardState(FeedbackContent)
@@ -21,9 +20,18 @@ final class FeedbackDetailViewModel: ViewModelable {
     @Published var continueFeedbackList: [FeedbackContent]
     @Published var stopFeedbackList: [FeedbackContent]
     @Published private(set) var errorMessage: String?
-    @Published private(set) var isLoading: Bool = false
     @Published var isDeleted = false
     @Published var isShowToast = false
+    
+    @Published private(set) var isDeleteLoading: Bool = false
+    @Published private(set) var isTransLoading: Bool = false
+    @Published private(set) var isUpdateCardStateLoading: Bool = false
+    @Published private(set) var isUpdateVisibleLoading: Bool = false
+    
+    var isLoading: Bool {
+        isDeleteLoading
+        || isUpdateVisibleLoading
+    }
     
     init(feedbackItem: Feedback) {
         self.feedbackItem = feedbackItem
@@ -35,8 +43,6 @@ final class FeedbackDetailViewModel: ViewModelable {
         switch action {
         case .deleteFeedback:
             deleteFeedback(feedbackItem: feedbackItem)
-        case .visualizeDetail(let detail):
-            updateVisibility(detail: detail)
         case .updateFeedbackVisibility:
             feedbackItem.visiable = true
             updateFeedbackVisibility()
@@ -51,7 +57,7 @@ final class FeedbackDetailViewModel: ViewModelable {
 extension FeedbackDetailViewModel {
     private func deleteFeedback(feedbackItem: Feedback) {
         Task {
-            isLoading = true
+            isDeleteLoading = true
             do {
                 try await FirestoreManager.shared.delete(feedbackItem)
                 print("피드백 삭제 성공")
@@ -60,33 +66,13 @@ extension FeedbackDetailViewModel {
                 errorMessage = "삭제 실패: \(error.localizedDescription)"
                 print("삭제 실패: \(error.localizedDescription)")
             }
-            isLoading = false
-        }
-    }
-    
-    private func updateVisibility(detail: FeedbackContent) {
-        guard let index = feedbackItem.content.firstIndex(where: { $0.id == detail.id }) else { return }
-        
-        feedbackItem.content[index].visiable.toggle()
-        
-        continueFeedbackList = feedbackItem.content.filter { $0.type == .typeContinue }
-        stopFeedbackList = feedbackItem.content.filter { $0.type == .typeStop }
-        
-        Task {
-            isLoading = true
-            do {
-                try await FirestoreManager.shared.update(feedbackItem)
-            } catch {
-                errorMessage = "원문 표시 실패: \(error.localizedDescription)"
-                print("원문 표시 실패: \(error.localizedDescription)")
-            }
-            isLoading = false
+            isDeleteLoading = false
         }
     }
     
     private func transFeedbackContent(content: FeedbackContent) {
         Task {
-            isLoading = true
+            isTransLoading = true
             let response = try await GPTManger.shared.sendChatCompletion(inputText: content.content)
                     
             guard let index = feedbackItem.content.firstIndex(where: { $0.id == content.id }) else { return }
@@ -101,7 +87,7 @@ extension FeedbackDetailViewModel {
                 errorMessage = "원문 표시 실패: \(error.localizedDescription)"
                 print("원문 표시 실패: \(error.localizedDescription)")
             }
-            isLoading = false
+            isTransLoading = false
         }
     }
     
@@ -114,27 +100,27 @@ extension FeedbackDetailViewModel {
         stopFeedbackList = feedbackItem.content.filter { $0.type == .typeStop }
         
         Task {
-            isLoading = true
+            isUpdateCardStateLoading = true
             do {
                 try await FirestoreManager.shared.update(feedbackItem)
             } catch {
                 errorMessage = "원문 표시 실패: \(error.localizedDescription)"
                 print("원문 표시 실패: \(error.localizedDescription)")
             }
-            isLoading = false
+            isUpdateCardStateLoading = false
         }
     }
     
     private func updateFeedbackVisibility() {
            Task {
-               isLoading = true
+               isUpdateVisibleLoading = true
                do {
                    try await FirestoreManager.shared.update(feedbackItem)
                } catch {
                    errorMessage = "원문 표시 실패: \(error.localizedDescription)"
                    print("원문 표시 실패: \(error.localizedDescription)")
                }
-               isLoading = false
+               isUpdateVisibleLoading = false
            }
        }
 }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
Flow2 부분 전체적인 로딩 뷰를 추가했습니다.
+ 채널 리스트 뷰에서 로딩과 아이템이 같이 보이는 이슈 수정

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->


|1|2|3|
|---|---|---|
|![1](https://github.com/user-attachments/assets/c71dba44-8dce-443a-b01c-8c8946bd89cf)|![Simulator Screen Recording - iPhone 16 - 2025-07-30 at 16 33 27](https://github.com/user-attachments/assets/15582785-4450-47de-916b-ce48e6b07d21)|![Simulator Screen Recording - iPhone 16 - 2025-07-30 at 16 33 35](https://github.com/user-attachments/assets/b0fce8cd-9c82-42fe-919a-7ef7aa7b8ed6)|

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
로딩하는 시간이 너무 짧아서 잘 안보일 수도 있습니다.
