### PR TITLE
피드백 디테일 무한 로딩 이슈 수정 및 카카오톡 템플릿 수정 (#161)

### DIFF
--- a/GimiFeedback/GimiFeedback/Network/KakaoShareManager.swift
+++ b/GimiFeedback/GimiFeedback/Network/KakaoShareManager.swift
@@ -41,8 +41,8 @@ extension KakaoShareManager {
     private func createFeedTemplate(channelID: String) -> FeedTemplate {
         
         let content = Content(
-            title: "기미 피드백",
-            description: "피드백을 남겨주세요",
+            title: "Gimme - 상처 없이 성장하기",
+               description: "링크를 통해 솔직한 피드백을 남겨주세요.",
             link: .init(
                 webUrl: URL(string: "https://developers.kakao.com/"),
                 mobileWebUrl: URL(string: "https://developers.kakao.com/"))
@@ -50,14 +50,7 @@ extension KakaoShareManager {
         
         let buttons = [
             Button(
-                title: "카카오 사이트 열기",
-                link: .init(
-                    webUrl: URL(string: "https://developers.kakao.com/"),
-                    mobileWebUrl: URL(string: "https://developers.kakao.com/"))
-            ),
-            
-            Button(
-                title: "앱에서 피드백 남기기",
+                title: "앱으로 이동하기",
                 link: .init(
                     webUrl: URL(string: "https://developers.kakao.com/"),
                     mobileWebUrl: URL(string: "https://developers.kakao.com/"),
@@ -67,3 +60,4 @@ extension KakaoShareManager {
         return FeedTemplate(content: content, buttons: buttons)
     }
 }
+

--- a/GimiFeedback/GimiFeedback/Network/KakaoShareManager.swift
+++ b/GimiFeedback/GimiFeedback/Network/KakaoShareManager.swift
@@ -60,4 +60,3 @@ extension KakaoShareManager {
         return FeedTemplate(content: content, buttons: buttons)
     }
 }
-

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
@@ -81,6 +81,7 @@ extension FeedbackDetailViewModel {
             
             continueFeedbackList = feedbackItem.content.filter { $0.type == .typeContinue }
             stopFeedbackList = feedbackItem.content.filter { $0.type == .typeStop }
+            
             do {
                 try await FirestoreManager.shared.update(feedbackItem)
             } catch {
@@ -95,6 +96,11 @@ extension FeedbackDetailViewModel {
         guard let index = feedbackItem.content.firstIndex(where: { $0.id == detail.id }) else { return }
         
         feedbackItem.content[index].cardState = detail.cardState
+        
+        if feedbackItem.content[index].cardState == .trans,
+           feedbackItem.content[index].transContent == nil {
+            return
+        }
         
         continueFeedbackList = feedbackItem.content.filter { $0.type == .typeContinue }
         stopFeedbackList = feedbackItem.content.filter { $0.type == .typeStop }
@@ -112,15 +118,16 @@ extension FeedbackDetailViewModel {
     }
     
     private func updateFeedbackVisibility() {
-           Task {
-               isUpdateVisibleLoading = true
-               do {
-                   try await FirestoreManager.shared.update(feedbackItem)
-               } catch {
-                   errorMessage = "원문 표시 실패: \(error.localizedDescription)"
-                   print("원문 표시 실패: \(error.localizedDescription)")
-               }
-               isUpdateVisibleLoading = false
-           }
-       }
+        Task {
+            isUpdateVisibleLoading = true
+            do {
+                try await FirestoreManager.shared.update(feedbackItem)
+            } catch {
+                errorMessage = "원문 표시 실패: \(error.localizedDescription)"
+                print("원문 표시 실패: \(error.localizedDescription)")
+            }
+            isUpdateVisibleLoading = false
+        }
+    }
 }
+

--- a/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
+++ b/GimiFeedback/GimiFeedback/Presentation/FeedbackDetail/FeedbackDetailViewModel.swift
@@ -130,4 +130,3 @@ extension FeedbackDetailViewModel {
         }
     }
 }
-


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
피드백 디테일 무한 로딩 이슈 수정 및 카카오톡 템플릿 수정을 수정했습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

|무한 로딩 (이슈)|무한 로딩 (이슈 수정)|
|---|---|
|![Simulator Screen Recording - iPhone 16 - 2025-07-30 at 22 52 54](https://github.com/user-attachments/assets/0b63a038-579e-4ddc-b7f2-408c8a120ac6)|![수정o](https://github.com/user-attachments/assets/dd4b6706-38da-48e8-a21a-f14dbfd721e3)|

|이전 템플릿|현재 템플릿|
|---|---|
|![전](https://github.com/user-attachments/assets/d22d7065-c715-455d-8aef-5aa3d6b5db36)|![후](https://github.com/user-attachments/assets/b510de18-33cd-4328-b5c6-232edd3210df)|





## 📍 PR Point 

기존에는 피드백 카드를 순화 모드로 전환할 때, GPT 변환 결과(transContent)가 아직 없는 상태에서도
cardState = .trans가 Firestore에 저장

그 결과, 다시 화면을 열면 cardState == .trans && transContent == nil 상태가 되어
무한 로딩 화면이 발생(로딩 뷰 설정을 위 조건과 같이 설정했었음)

그래서 최초 순화 시 cardState와 transContent가 모두 설정된 경우에만 Firestore 업데이트가 일어나도록 변경