### PR TITLE
파이썬 양자화 코드 추가 (#186)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 GimiFeedback/GimiFeedback/AI/MLWeights/*.mlpackage/** filter=lfs diff=lfs merge=lfs -text
 GimiFeedback/GimiFeedback/AI/MLWeights/*.mlpackage/*  filter=lfs diff=lfs merge=lfs -text
 GimiFeedback/GimiFeedback/AI/MLWeights/*.mlpackage    filter=lfs diff=lfs merge=lfs -text
+*.mlpackage/Data/com.apple.CoreML/weights/*.bin filter=lfs diff=lfs merge=lfs -text

--- a/ai/converting/convert_model_to_mlpackage.py
+++ b/ai/converting/convert_model_to_mlpackage.py
@@ -109,19 +109,94 @@ print(
     f"Input dtypes: input_ids={input_ids.dtype}, attention_mask={attention_mask.dtype}, token_type_ids={token_type_ids.dtype}"
 )
 
-output = mlmodel.predict(
-    {
-        "input_ids": input_ids,
-        "attention_mask": attention_mask,
-        "token_type_ids": token_type_ids,
-    }
-)
+test_input = {
+    "input_ids": input_ids,
+    "attention_mask": attention_mask,
+    "token_type_ids": token_type_ids,
+}
+
+output = mlmodel.predict(test_input)
 print(output)
 
+from pathlib import Path
 
+model_name = "KcELECTRA-base-v2022"
+
+directory = Path(f"{model_name}.mlpackage").absolute().as_posix()
+weights_dir = f"{directory}/Data/com.apple.CoreML/weights/weight.bin"
 # 모델 저장
-mlmodel.save("KcELECTRA-base-v2022.mlpackage")
-print("\n✅ Model successfully converted and saved as 'KcELECTRA-base-v2022.mlpackage'")
+mlmodel.save(directory)
+print(f"\n✅ Model successfully converted and saved as '{directory}'")
 print(
     f"✅ Test prediction successful: {output['classLabel']} (confidence: {max(output['classLabel_probs'].values()):.4f})"
+)
+
+# mlmodel_fp32 = ct.models.MLModel(directory)
+from coremltools.optimize.coreml import OptimizationConfig, OpLinearQuantizerConfig
+
+config = OptimizationConfig(
+    global_config=OpLinearQuantizerConfig(
+        mode="linear_symmetric",  # 대칭적 선형 양자화
+        dtype="int8",  # INT8로 양자화
+        granularity="per_channel",  # 채널별 양자화
+        weight_threshold=512,  # 512개 이상 가중치만 양자화
+    )
+)
+
+
+model_int8 = ct.optimize.coreml.linear_quantize_weights(mlmodel, config)
+print("Model test int8")
+
+output_int8 = model_int8.predict(test_input)
+print(output_int8)
+
+
+def analyze_quantization(
+    original_path: str,
+    quantized_path: str,
+    test_input: dict,
+) -> None:
+    """양자화 결과를 분석하는 함수"""
+
+    original_model = ct.models.MLModel(original_path)
+    quantized_model = ct.models.MLModel(quantized_path)
+
+    # 크기 비교
+    orig_size = sum(
+        f.stat().st_size for f in Path(original_path).rglob("*") if f.is_file()
+    )
+    quant_size = sum(
+        f.stat().st_size for f in Path(quantized_path).rglob("*") if f.is_file()
+    )
+
+    print("🔍 양자화 분석 결과:")
+    print(f"   원본 크기: {orig_size / (1024**2):.2f} MB")
+    print(f"   양자화 크기: {quant_size / (1024**2):.2f} MB")
+    print(f"   압축 비율: {orig_size / quant_size:.2f}x")
+
+    orig_output = original_model.predict(test_input)
+    quant_output = quantized_model.predict(test_input)
+
+    # 확률 차이 계산
+    orig_probs = list(orig_output["classLabel_probs"].values())
+    quant_probs = list(quant_output["classLabel_probs"].values())
+
+    max_diff = max(abs(o - q) for o, q in zip(orig_probs, quant_probs))
+
+    print(
+        f"   예측 클래스: 원본={orig_output['classLabel']}, 양자화={quant_output['classLabel']}"
+    )
+    print(f"   최대 확률 차이: {max_diff:.6f}")
+    print(f"   양자화 성공: {'✅' if quant_size < orig_size * 0.8 else '❌'}")
+
+
+analyze_quantization(
+    f"{model_name}.mlpackage", f"{model_name}-int8.mlpackage", test_input
+)
+
+fp_dir = Path(f"{model_name}-int8.mlpackage").absolute().as_posix()
+model_int8.save(fp_dir)
+print(f"\n✅ Model successfully converted and saved as '{fp_dir}'")
+print(
+    f"✅ Test prediction successful: {output_int8['classLabel']} (confidence: {max(output_int8['classLabel_probs'].values()):.4f})"
 )


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
quantization(양자화) 하는 코드 추가했습니다.

## 버그 리포트
fp32 -> fp16으로 변환할 경우 잘 안되서 int8로 변경하였습니다.
- fp32 : 487MB, fp16 : 240MB, int8 105MB 정도 됩니다.
- 여기서 양자화는 모델의 자료형만 바꿉니다.

## 특징
- 모델의 자료형만 바꾸고 입력 텐서의 자료형은 fp32 그대로입니다.
- 입력 자료형이 fp32 그대로일 경우 모델의 예측력이 거의 떨어지지 않는 것을 확인하였습니다.
- 이 부분은 애플에서 양자화하는 방식이 있는 것으로 추정합니다.

<img width="1303" height="310" alt="스크린샷 2025-09-02 오후 1 47 11" src="https://github.com/user-attachments/assets/1868e262-9f7b-40d2-9df7-2f7a34e886d6" />

위의 이미지를 보면 위의 빨간색 바운딩 박스가 fp32 모델, 아래 빨간색 바운딩 박스가 int8입니다.
- 모델의 예측력이 어떻게 차이가 적은지 확인하는 방법은 `classLabel_probs`의 차이가 적을 수록 원본 모델과 가까운 예측력을 보이기 때문에 두 `classLabel_probs`의 각 클래스별 prob값의 차이가 0.01 보다 적으면 좋습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
